### PR TITLE
fix(mdx): mermaid \n → <br/> (invalid SVG XML)

### DIFF
--- a/CUTOVER.md
+++ b/CUTOVER.md
@@ -80,7 +80,7 @@ function) before cutover.
    `.github/workflows/redirect-pages.yml`. GitHub Pages serves `404.html`
    for unknown deep links, so *every* old URL
    (`emersonbraun.github.io/ai-summary-hub/...`) bounces to the matching
-   path on `https://aisummaryhub.dev`, dropping unsupported locales
+   path on `https://ai-hub.emersonbraun.dev`, dropping unsupported locales
    (es/fr/de/zh-Hans → EN) and keeping `pt-BR`. To activate: repo Settings
    → Pages → Source = GitHub Actions, then run the workflow once.
 4. Update any external backlinks pointing at the old GH Pages URL

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -16,6 +16,10 @@ const config: Config = {
   url: 'https://emersonbraun.github.io',
   baseUrl: '/ai-summary-hub/',
 
+  // Legacy app kept for reference; deployed Docusaurus only redirects to the
+  // new Fumadocs app. See src/clientModules/redirectToApp.js + redirect/.
+  clientModules: ['./src/clientModules/redirectToApp.js'],
+
   organizationName: 'EmersonBraun',
   projectName: 'ai-summary-hub',
 

--- a/next/components/mermaid.tsx
+++ b/next/components/mermaid.tsx
@@ -11,13 +11,26 @@ export function Mermaid({ chart }: { chart: string }) {
     void (async () => {
       const { default: mermaid } = await import('mermaid');
       if (cancelled) return;
-      mermaid.initialize({ startOnLoad: false, securityLevel: 'strict' });
+      mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: 'strict',
+        // htmlLabels emits <br> inside foreignObject — invalid XML that breaks
+        // DOMParser(image/svg+xml). Force SVG <text> labels instead.
+        htmlLabels: false,
+        flowchart: { htmlLabels: false },
+      });
       try {
         const { svg } = await mermaid.render(`m-${id}`, chart);
         if (cancelled || !ref.current) return;
         const parser = new DOMParser();
-        const doc = parser.parseFromString(svg, 'image/svg+xml');
-        const node = doc.documentElement;
+        let doc = parser.parseFromString(svg, 'image/svg+xml');
+        // If strict XML parsing failed (e.g. a stray <br>), re-parse as HTML
+        // and lift the <svg> out — never inject the XML-error document.
+        if (doc.querySelector('parsererror')) {
+          doc = parser.parseFromString(svg, 'text/html');
+        }
+        const node = doc.querySelector('svg');
+        if (cancelled || !ref.current || !node) return;
         ref.current.replaceChildren(node);
       } catch (err) {
         if (cancelled || !ref.current) return;

--- a/next/content/docs/en/agents/agent-runtimes.mdx
+++ b/next/content/docs/en/agents/agent-runtimes.mdx
@@ -30,9 +30,9 @@ Paperclip (released March 2026) is a Node.js server + React UI that organizes *e
 
 ```mermaid
 flowchart TD
-  Need{What is the hard part?} -->|Build the agent app in JS| AK[AgentsKit\nfull-stack framework]
-  Need -->|One agent that persists\nand self-improves| HM[Hermes Agent\nself-hosted runtime]
-  Need -->|Coordinate many existing\nagents with oversight| PC[Paperclip\nUI orchestrator]
+  Need{What is the hard part?} -->|Build the agent app in JS| AK[AgentsKit<br/>full-stack framework]
+  Need -->|One agent that persists<br/>and self-improves| HM[Hermes Agent<br/>self-hosted runtime]
+  Need -->|Coordinate many existing<br/>agents with oversight| PC[Paperclip<br/>UI orchestrator]
   AK --> Prod[Production agent system]
   HM --> Prod
   PC --> Prod

--- a/next/content/docs/en/agents/anthropic-tool-use.mdx
+++ b/next/content/docs/en/agents/anthropic-tool-use.mdx
@@ -36,7 +36,7 @@ Complex tasks often require several rounds of tool calls before Claude can produ
 
 ```mermaid
 flowchart LR
-  User[User message] -->|appended to messages| API[Anthropic API\nClaude model]
+  User[User message] -->|appended to messages| API[Anthropic API<br/>Claude model]
   API -->|stop_reason: tool_use| Parse[Parse tool_use blocks]
   Parse -->|one block per tool call| Exec[Execute tools in parallel]
   Exec -->|results| Wrap[Wrap in tool_result blocks]

--- a/next/content/docs/en/agents/autogen.mdx
+++ b/next/content/docs/en/agents/autogen.mdx
@@ -39,7 +39,7 @@ flowchart LR
   Human[Human / Initiator] -->|initial message| UPA[UserProxyAgent]
   UPA -->|sends message| AA[AssistantAgent]
   AA -->|generates reply with code| UPA
-  UPA -->|executes code block| Exec[Code executor\nsubprocess / Docker]
+  UPA -->|executes code block| Exec[Code executor<br/>subprocess / Docker]
   Exec -->|stdout / stderr| UPA
   UPA -->|reports result| AA
   AA -->|revised reply or TERMINATE| UPA

--- a/next/content/docs/en/agents/conversational-memory.mdx
+++ b/next/content/docs/en/agents/conversational-memory.mdx
@@ -33,12 +33,12 @@ Entity memory extracts named entities—people, places, products, preferences—
 
 ```mermaid
 flowchart TD
-  Msg[New User Message] -->|"add to"| Buffer[Buffer Memory\nlast N turns]
-  Msg -->|"embed query"| VectorDB[(Vector Memory\nembedding store)]
+  Msg[New User Message] -->|"add to"| Buffer[Buffer Memory<br/>last N turns]
+  Msg -->|"embed query"| VectorDB[(Vector Memory<br/>embedding store)]
   VectorDB -->|"retrieve similar turns"| Merge[Context Assembly]
   Buffer -->|"recent verbatim turns"| Merge
-  Summary[Summary Memory\nrunning narrative] -->|"inject summary"| Merge
-  Entities[Entity Memory\nkey facts / profiles] -->|"relevant entities"| Merge
+  Summary[Summary Memory<br/>running narrative] -->|"inject summary"| Merge
+  Entities[Entity Memory<br/>key facts / profiles] -->|"relevant entities"| Merge
   Merge -->|"assembled context"| LLM[LLM Inference]
   LLM -->|"response"| Out[Agent Output]
   LLM -->|"trigger summarize"| Summarizer[Summarizer LLM]

--- a/next/content/docs/en/agents/crewai.mdx
+++ b/next/content/docs/en/agents/crewai.mdx
@@ -36,11 +36,11 @@ CrewAI ships with a `@tool` decorator compatible with LangChain tools, making it
 ```mermaid
 flowchart TD
   Input[User goal / kickoff input] -->|starts| Crew[Crew orchestrator]
-  Crew -->|assigns task 1| Agent1[Researcher agent\nrole + goal + tools]
+  Crew -->|assigns task 1| Agent1[Researcher agent<br/>role + goal + tools]
   Agent1 -->|calls tools| Tools1[Web search / APIs]
   Tools1 -->|observation| Agent1
   Agent1 -->|task 1 output| Crew
-  Crew -->|injects context, assigns task 2| Agent2[Writer agent\nrole + goal + tools]
+  Crew -->|injects context, assigns task 2| Agent2[Writer agent<br/>role + goal + tools]
   Agent2 -->|calls tools| Tools2[File I/O / Code]
   Tools2 -->|observation| Agent2
   Agent2 -->|task 2 output| Crew

--- a/next/content/docs/en/agents/dag-agents.mdx
+++ b/next/content/docs/en/agents/dag-agents.mdx
@@ -35,11 +35,11 @@ In dynamic mode, a planning step runs first and outputs a graph specification (e
 
 ```mermaid
 flowchart LR
-  Start[User Goal] -->|"decompose goal"| TaskA[Task A\nResearch Topic 1]
-  Start -->|"decompose goal"| TaskB[Task B\nResearch Topic 2]
-  TaskA -->|"research result A"| TaskC[Task C\nSynthesize Results]
+  Start[User Goal] -->|"decompose goal"| TaskA[Task A<br/>Research Topic 1]
+  Start -->|"decompose goal"| TaskB[Task B<br/>Research Topic 2]
+  TaskA -->|"research result A"| TaskC[Task C<br/>Synthesize Results]
   TaskB -->|"research result B"| TaskC
-  TaskC -->|"synthesis"| TaskD[Task D\nWrite Final Report]
+  TaskC -->|"synthesis"| TaskD[Task D<br/>Write Final Report]
   TaskD -->|"report"| Output[Final Output]
 ```
 

--- a/next/content/docs/en/agents/langgraph.mdx
+++ b/next/content/docs/en/agents/langgraph.mdx
@@ -36,12 +36,12 @@ LangGraph handles cycles natively: a node can edge back to a previous node (or i
 
 ```mermaid
 flowchart TD
-  Start([START]) -->|initializes state| CallModel[call_model node\nLLM generates response]
-  CallModel -->|reads tool_calls from state| Router{tools_router\nconditional edge}
-  Router -->|tool_calls present| ToolNode[tool_node\nexecutes tool calls]
+  Start([START]) -->|initializes state| CallModel[call_model node<br/>LLM generates response]
+  CallModel -->|reads tool_calls from state| Router{tools_router<br/>conditional edge}
+  Router -->|tool_calls present| ToolNode[tool_node<br/>executes tool calls]
   ToolNode -->|appends tool results to state| CallModel
-  Router -->|no tool_calls| End([END\nfinal answer])
-  CallModel -->|on error| ErrorHandler[error_handler node\nretry or escalate]
+  Router -->|no tool_calls| End([END<br/>final answer])
+  CallModel -->|on error| ErrorHandler[error_handler node<br/>retry or escalate]
   ErrorHandler -->|retry| CallModel
   ErrorHandler -->|max retries exceeded| End
 ```

--- a/next/content/docs/en/agents/memory.mdx
+++ b/next/content/docs/en/agents/memory.mdx
@@ -39,9 +39,9 @@ The retrieval loop connects all layers. On each turn, the agent queries long-ter
 
 ```mermaid
 flowchart LR
-  Input[User Input] -->|"new message"| WM[Working Memory\nContext Window]
+  Input[User Input] -->|"new message"| WM[Working Memory<br/>Context Window]
   WM -->|"query embedding"| Retrieval[Retrieval Engine]
-  Retrieval -->|"semantic search"| LTS[Long-term Store\nVector DB]
+  Retrieval -->|"semantic search"| LTS[Long-term Store<br/>Vector DB]
   LTS -->|"relevant chunks"| WM
   WM -->|"recent N turns"| STB[Short-term Buffer]
   STB -->|"inject history"| WM

--- a/next/content/docs/en/agents/self-critique.mdx
+++ b/next/content/docs/en/agents/self-critique.mdx
@@ -35,12 +35,12 @@ Reflexion (Shinn et al., 2023) applies reflection at the episode level rather th
 
 ```mermaid
 flowchart TD
-  Task[Input Task] -->|"initial prompt"| Generate[Generate\nInitial Output]
-  Generate -->|"draft output"| Evaluate[Evaluate\nCritic LLM]
-  Evaluate -->|"score + critique"| Decision{Score >=\nthreshold?}
+  Task[Input Task] -->|"initial prompt"| Generate[Generate<br/>Initial Output]
+  Generate -->|"draft output"| Evaluate[Evaluate<br/>Critic LLM]
+  Evaluate -->|"score + critique"| Decision{Score >=<br/>threshold?}
   Decision -->|"yes — accept"| Accept[Final Output]
-  Decision -->|"no — refine"| Critique[Critique\nStructured Feedback]
-  Critique -->|"feedback + draft"| Refine[Refine\nRevision LLM]
+  Decision -->|"no — refine"| Critique[Critique<br/>Structured Feedback]
+  Critique -->|"feedback + draft"| Refine[Refine<br/>Revision LLM]
   Refine -->|"revised output"| Evaluate
   Refine -->|"max iterations reached"| Accept
 ```

--- a/next/content/docs/en/agents/tools-actions.mdx
+++ b/next/content/docs/en/agents/tools-actions.mdx
@@ -35,10 +35,10 @@ Modern LLM APIs support parallel tool calls: the model can request multiple tool
 
 ```mermaid
 flowchart LR
-  User[User Message] -->|"message + tool schemas"| Agent[Agent / LLM\nReasoning]
-  Agent -->|"selects tool"| ToolSelection[Tool Selection\nFunction Call Object]
-  ToolSelection -->|"dispatch"| ToolExec[Tool Execution\nPython Function]
-  ToolExec -->|"calls"| External[External Service\nAPI / DB / Web]
+  User[User Message] -->|"message + tool schemas"| Agent[Agent / LLM<br/>Reasoning]
+  Agent -->|"selects tool"| ToolSelection[Tool Selection<br/>Function Call Object]
+  ToolSelection -->|"dispatch"| ToolExec[Tool Execution<br/>Python Function]
+  ToolExec -->|"calls"| External[External Service<br/>API / DB / Web]
   External -->|"raw result"| ToolExec
   ToolExec -->|"formatted result"| Agent
   Agent -->|"continue reasoning or answer"| Agent

--- a/next/content/docs/en/claude-code/claude-md.mdx
+++ b/next/content/docs/en/claude-code/claude-md.mdx
@@ -36,9 +36,9 @@ Because `CLAUDE.md` is injected on every request, outdated instructions actively
 
 ```mermaid
 flowchart LR
-  Global["~/.claude/CLAUDE.md\n(global)"] -->|loaded first| Merge[Merged system prompt]
-  Root["project-root/CLAUDE.md\n(project)"] -->|overrides global| Merge
-  Sub["src/feature/CLAUDE.md\n(subdirectory, optional)"] -->|narrowest scope| Merge
+  Global["~/.claude/CLAUDE.md<br/>(global)"] -->|loaded first| Merge[Merged system prompt]
+  Root["project-root/CLAUDE.md<br/>(project)"] -->|overrides global| Merge
+  Sub["src/feature/CLAUDE.md<br/>(subdirectory, optional)"] -->|narrowest scope| Merge
   Merge -->|injected into| Session[Claude Code session]
   Session -->|persistent for entire session| LLM[Claude model]
 ```

--- a/next/content/docs/en/claude-code/context-management.mdx
+++ b/next/content/docs/en/claude-code/context-management.mdx
@@ -42,7 +42,7 @@ flowchart LR
   FileRead[File contents loaded] -->|appended to history| History
   Assemble -->|sent to| Model[Claude model]
   Model -->|response + new tool calls| History
-  History -->|approaching limit| Compress[Auto-compression\nold turns summarized]
+  History -->|approaching limit| Compress[Auto-compression<br/>old turns summarized]
   Compress -->|trimmed history| Assemble
   Clear[/clear command] -->|resets| History
 ```

--- a/next/content/docs/en/claude-code/mcp-plugins.mdx
+++ b/next/content/docs/en/claude-code/mcp-plugins.mdx
@@ -36,11 +36,11 @@ MCP servers handle their own authentication. A GitHub MCP server, for example, r
 
 ```mermaid
 flowchart LR
-  Dev[Developer request] -->|natural language| ClaudeCode[Claude Code\nMCP client]
+  Dev[Developer request] -->|natural language| ClaudeCode[Claude Code<br/>MCP client]
   ClaudeCode -->|initialize + list tools| MCPServer[MCP Server]
   MCPServer -->|tool manifest| ClaudeCode
   ClaudeCode -->|tool call request| MCPServer
-  MCPServer -->|calls external service| External[External Service\ne.g. GitHub, DB, Jira]
+  MCPServer -->|calls external service| External[External Service<br/>e.g. GitHub, DB, Jira]
   External -->|response| MCPServer
   MCPServer -->|tool result| ClaudeCode
   ClaudeCode -->|result injected into context| Model[Claude model]

--- a/next/content/docs/en/claude-code/prompt-caching.mdx
+++ b/next/content/docs/en/claude-code/prompt-caching.mdx
@@ -37,9 +37,9 @@ The API response includes a `usage` object that distinguishes between regular in
 ```mermaid
 flowchart LR
   Req1[First API request] -->|cache_control marker| Build[Build cache entry]
-  Build -->|stores KV state| Cache[Prompt cache\n5 min TTL]
-  Req2[Second API request\nsame prefix] -->|prefix matches| Hit[Cache hit]
-  Hit -->|skip reprocessing| Fast[Fast response\n0.1x token cost]
+  Build -->|stores KV state| Cache[Prompt cache<br/>5 min TTL]
+  Req2[Second API request<br/>same prefix] -->|prefix matches| Hit[Cache hit]
+  Hit -->|skip reprocessing| Fast[Fast response<br/>0.1x token cost]
   Req3[Request after 5 min idle] -->|cache expired| Miss[Cache miss]
   Miss -->|rebuild cache| Build
 ```

--- a/next/content/docs/en/cost-optimization/index.mdx
+++ b/next/content/docs/en/cost-optimization/index.mdx
@@ -22,14 +22,14 @@ Cost is determined by four factors: the number of **input tokens** sent to the m
 
 ```mermaid
 flowchart LR
-  Request[Incoming query] --> Cache{Semantic cache\nhit?}
-  Cache -->|Yes| Return[Return cached response\n100% savings]
-  Cache -->|No| Router[Model router\ncomplexity classifier]
-  Router -->|simple| Cheap[Small model\ne.g. Haiku / GPT-4o-mini]
-  Router -->|complex| Premium[Premium model\ne.g. Opus / GPT-4o]
-  Cheap --> PromptCache{Prompt prefix\ncached?}
+  Request[Incoming query] --> Cache{Semantic cache<br/>hit?}
+  Cache -->|Yes| Return[Return cached response<br/>100% savings]
+  Cache -->|No| Router[Model router<br/>complexity classifier]
+  Router -->|simple| Cheap[Small model<br/>e.g. Haiku / GPT-4o-mini]
+  Router -->|complex| Premium[Premium model<br/>e.g. Opus / GPT-4o]
+  Cheap --> PromptCache{Prompt prefix<br/>cached?}
   Premium --> PromptCache
-  PromptCache -->|Yes| Discount[90% input cost discount\nAnthropic / 50% OpenAI]
+  PromptCache -->|Yes| Discount[90% input cost discount<br/>Anthropic / 50% OpenAI]
   PromptCache -->|No| Full[Full price inference]
   Discount --> Store[Store in semantic cache]
   Full --> Store

--- a/next/content/docs/en/cost-optimization/model-tiering.mdx
+++ b/next/content/docs/en/cost-optimization/model-tiering.mdx
@@ -20,13 +20,13 @@ Industry data from 2025–2026 consistently shows that 50–70% of enterprise LL
 
 ```mermaid
 flowchart TD
-  Query[Incoming query] --> SemCache{Semantic cache\nhit? cosine ≥ 0.92}
-  SemCache -->|Yes| CacheReturn[Return cached response\n0 tokens consumed]
-  SemCache -->|No| Classifier[Complexity classifier\nsmall model / rule-based]
-  Classifier -->|score ≤ 0.4\nsimple| Tier1[Tier 1 — small model\nHaiku / GPT-4o-mini\n~$0.15/1M tokens]
-  Classifier -->|0.4–0.75\nmedium| Tier2[Tier 2 — mid model\nSonnet / GPT-4o\n~$3/1M tokens]
-  Classifier -->|score > 0.75\ncomplex| Tier3[Tier 3 — premium\nOpus / o3\n~$15/1M tokens]
-  Tier1 --> ConfCheck{Output confidence\n≥ threshold?}
+  Query[Incoming query] --> SemCache{Semantic cache<br/>hit? cosine ≥ 0.92}
+  SemCache -->|Yes| CacheReturn[Return cached response<br/>0 tokens consumed]
+  SemCache -->|No| Classifier[Complexity classifier<br/>small model / rule-based]
+  Classifier -->|score ≤ 0.4<br/>simple| Tier1[Tier 1 — small model<br/>Haiku / GPT-4o-mini<br/>~$0.15/1M tokens]
+  Classifier -->|0.4–0.75<br/>medium| Tier2[Tier 2 — mid model<br/>Sonnet / GPT-4o<br/>~$3/1M tokens]
+  Classifier -->|score > 0.75<br/>complex| Tier3[Tier 3 — premium<br/>Opus / o3<br/>~$15/1M tokens]
+  Tier1 --> ConfCheck{Output confidence<br/>≥ threshold?}
   ConfCheck -->|No| Escalate[Escalate to Tier 2]
   ConfCheck -->|Yes| Store[Store in semantic cache]
   Tier2 --> Store

--- a/next/content/docs/en/cost-optimization/prompt-caching.mdx
+++ b/next/content/docs/en/cost-optimization/prompt-caching.mdx
@@ -23,11 +23,11 @@ Prompt caching delivers the greatest benefit when the same large prefix is reuse
 
 ```mermaid
 flowchart LR
-  Request[New request\nsystem + docs + user query] --> Split[Split at cache breakpoint]
-  Split -->|Prefix ≤ breakpoint| Check{KV-cache\nhit?}
-  Split -->|Suffix after breakpoint| Always[Always computed\nfull price]
-  Check -->|Hit| Cheap[Cached tokens\n10% price Anthropic\n50% price OpenAI]
-  Check -->|Miss| Full[Full price\n+ cache write fee]
+  Request[New request<br/>system + docs + user query] --> Split[Split at cache breakpoint]
+  Split -->|Prefix ≤ breakpoint| Check{KV-cache<br/>hit?}
+  Split -->|Suffix after breakpoint| Always[Always computed<br/>full price]
+  Check -->|Hit| Cheap[Cached tokens<br/>10% price Anthropic<br/>50% price OpenAI]
+  Check -->|Miss| Full[Full price<br/>+ cache write fee]
   Cheap --> Merge[Merge KV states]
   Full --> Merge
   Always --> Merge

--- a/next/content/docs/en/cost-optimization/token-budgeting.mdx
+++ b/next/content/docs/en/cost-optimization/token-budgeting.mdx
@@ -17,14 +17,14 @@ Input tokens comprise: the system prompt, conversation history, retrieved RAG co
 
 ```mermaid
 flowchart TD
-  Raw[Raw inputs\nsystem + history + context + query] --> Compress[Prompt compression\nLLMLingua / selective summarisation]
-  Compress --> Trim[RAG context trimmer\ntop-k chunks, token cap]
-  Trim --> Prune[History pruner\nsliding window / abstractive summary]
-  Prune --> Budget{Total tokens\n≤ budget?}
+  Raw[Raw inputs<br/>system + history + context + query] --> Compress[Prompt compression<br/>LLMLingua / selective summarisation]
+  Compress --> Trim[RAG context trimmer<br/>top-k chunks, token cap]
+  Trim --> Prune[History pruner<br/>sliding window / abstractive summary]
+  Prune --> Budget{Total tokens<br/>≤ budget?}
   Budget -->|Yes| LLM[Send to LLM]
   Budget -->|No| Drop[Drop lowest-score chunks]
   Drop --> LLM
-  LLM --> MaxTok[max_tokens / stop sequence\noutput constraint]
+  LLM --> MaxTok[max_tokens / stop sequence<br/>output constraint]
   MaxTok --> Response[Bounded response]
 ```
 

--- a/next/content/docs/en/edge-ai/onnx.mdx
+++ b/next/content/docs/en/edge-ai/onnx.mdx
@@ -22,10 +22,10 @@ flowchart LR
   PyTorch["PyTorch Model"] -->|"torch.onnx.export()"| ONNX["ONNX Model (.onnx)"]
   TF["TensorFlow / Keras"] -->|"tf2onnx convert"| ONNX
   SKLearn["scikit-learn / XGBoost"] -->|"skl2onnx / onnxmltools"| ONNX
-  ONNX -->|"ort.InferenceSession()"| ORT["ONNX Runtime\nSession"]
-  ORT -->|"graph optimizations"| GraphOpt["Optimized Graph\n(fused ops, constants folded)"]
-  GraphOpt -->|"EP selection"| EP["Execution Provider\n(CPU / CUDA / TensorRT / CoreML / NNAPI)"]
-  EP -->|"kernel dispatch"| Device["Target Device\n(CPU, GPU, NPU)"]
+  ONNX -->|"ort.InferenceSession()"| ORT["ONNX Runtime<br/>Session"]
+  ORT -->|"graph optimizations"| GraphOpt["Optimized Graph<br/>(fused ops, constants folded)"]
+  GraphOpt -->|"EP selection"| EP["Execution Provider<br/>(CPU / CUDA / TensorRT / CoreML / NNAPI)"]
+  EP -->|"kernel dispatch"| Device["Target Device<br/>(CPU, GPU, NPU)"]
 ```
 
 ### ONNX Format and Model Interoperability

--- a/next/content/docs/en/edge-ai/pytorch-mobile.mdx
+++ b/next/content/docs/en/edge-ai/pytorch-mobile.mdx
@@ -19,12 +19,12 @@ Google and Meta jointly developed **ExecuTorch** as the next-generation framewor
 
 ```mermaid
 flowchart LR
-  PyModel["PyTorch Model\n(nn.Module)"] -->|"torch.jit.trace / script"| TorchScript["TorchScript\nScriptModule"]
-  PyModel -->|"torch.export.export"| ExportedProgram["ExportedProgram\n(ATen IR)"]
+  PyModel["PyTorch Model<br/>(nn.Module)"] -->|"torch.jit.trace / script"| TorchScript["TorchScript<br/>ScriptModule"]
+  PyModel -->|"torch.export.export"| ExportedProgram["ExportedProgram<br/>(ATen IR)"]
   TorchScript -->|"optimize_for_mobile"| PTL[".ptl Bundle"]
-  ExportedProgram -->|"to_edge + link + serialize"| PTE[".pte Bundle\n(ExecuTorch)"]
-  PTL -->|"Module.load()"| LibTorch["LibTorch\nMobile Runtime"]
-  PTE -->|"Module::load()"| ETRuntime["ExecuTorch\nRuntime"]
+  ExportedProgram -->|"to_edge + link + serialize"| PTE[".pte Bundle<br/>(ExecuTorch)"]
+  PTL -->|"Module.load()"| LibTorch["LibTorch<br/>Mobile Runtime"]
+  PTE -->|"Module::load()"| ETRuntime["ExecuTorch<br/>Runtime"]
   LibTorch -->|"forward()"| Device["Android / iOS Device"]
   ETRuntime -->|"execute()"| Device
 ```

--- a/next/content/docs/en/edge-ai/tflite.mdx
+++ b/next/content/docs/en/edge-ai/tflite.mdx
@@ -22,7 +22,7 @@ flowchart LR
   TF["TensorFlow / Keras Model"] -->|"saved_model or .h5"| Converter["TFLite Converter"]
   Converter -->|"quantize / optimize"| FlatBuffer[".tflite FlatBuffer"]
   FlatBuffer -->|"load via Python / C++ / Java"| Interpreter["TFLite Interpreter"]
-  Interpreter -->|"delegate selection"| Delegate["Hardware Delegate\n(GPU / NNAPI / CoreML)"]
+  Interpreter -->|"delegate selection"| Delegate["Hardware Delegate<br/>(GPU / NNAPI / CoreML)"]
   Delegate -->|"accelerated kernels"| Device["Target Device"]
 ```
 

--- a/next/content/docs/en/edge-reasoning/index.mdx
+++ b/next/content/docs/en/edge-reasoning/index.mdx
@@ -19,11 +19,11 @@ Applications range from offline-capable voice assistants and wearables to autono
 
 ```mermaid
 flowchart LR
-  Input["Sensor / user input\n(text, audio, image)"] -->|"preprocess on-device"| PreProc["Preprocessing\n(tokenize / resize)"]
-  PreProc -->|"feed"| SmallModel["Small / compressed model\n(quantized transformer / CNN)"]
+  Input["Sensor / user input<br/>(text, audio, image)"] -->|"preprocess on-device"| PreProc["Preprocessing<br/>(tokenize / resize)"]
+  PreProc -->|"feed"| SmallModel["Small / compressed model<br/>(quantized transformer / CNN)"]
   SmallModel -->|"forward pass"| Confidence["Confidence check"]
-  Confidence -->|"high confidence\n(early exit)"| Output["On-device output"]
-  Confidence -->|"low confidence\n(optional fallback)"| Cloud["Cloud model\n(when online)"]
+  Confidence -->|"high confidence<br/>(early exit)"| Output["On-device output"]
+  Confidence -->|"low confidence<br/>(optional fallback)"| Cloud["Cloud model<br/>(when online)"]
   Cloud -->|"refined answer"| Output
 ```
 
@@ -31,8 +31,8 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  Prompt["Short prompt"] -->|"draft tokens"| DraftModel["Tiny draft model\n(on-device)"]
-  DraftModel -->|"candidate tokens"| VerifyModel["Larger verify model\n(cloud or bigger on-device)"]
+  Prompt["Short prompt"] -->|"draft tokens"| DraftModel["Tiny draft model<br/>(on-device)"]
+  DraftModel -->|"candidate tokens"| VerifyModel["Larger verify model<br/>(cloud or bigger on-device)"]
   VerifyModel -->|"accept / reject"| Output["Final tokens"]
 ```
 

--- a/next/content/docs/en/embeddings/fine-tuning-embeddings.mdx
+++ b/next/content/docs/en/embeddings/fine-tuning-embeddings.mdx
@@ -18,14 +18,14 @@ The standard training objective is **contrastive loss** (InfoNCE / NT-Xent): for
 
 ```mermaid
 flowchart TD
-  Data[Training pairs\nquery + positive + hard negatives] --> Tokenize[Tokenise query and document]
-  Tokenize --> Encoder[Encoder forward pass\nshared weights]
+  Data[Training pairs<br/>query + positive + hard negatives] --> Tokenize[Tokenise query and document]
+  Tokenize --> Encoder[Encoder forward pass<br/>shared weights]
   Encoder --> Pool[Mean pooling → embedding]
-  Pool --> Loss[Contrastive loss\nInfoNCE / MultipleNegativesRanking]
+  Pool --> Loss[Contrastive loss<br/>InfoNCE / MultipleNegativesRanking]
   Loss --> Grad[Backpropagation]
-  Grad --> Update[Weight update\nAdamW + LR schedule]
+  Grad --> Update[Weight update<br/>AdamW + LR schedule]
   Update -->|repeat| Tokenize
-  Update -->|eval| BEIR[Evaluate on BEIR / MTEB subset\nnDCG@10]
+  Update -->|eval| BEIR[Evaluate on BEIR / MTEB subset<br/>nDCG@10]
 ```
 
 ### Training data

--- a/next/content/docs/en/embeddings/index.mdx
+++ b/next/content/docs/en/embeddings/index.mdx
@@ -26,11 +26,11 @@ The key properties of an embedding model are:
 ```mermaid
 flowchart LR
   Text[Input text] --> Tokenizer[Tokenizer]
-  Tokenizer --> Encoder[Transformer encoder\nBERT / RoBERTa / custom]
-  Encoder --> Pool[Pooling\nmean / CLS / weighted]
-  Pool --> Project[Linear projection\noptional dimension reduction]
+  Tokenizer --> Encoder[Transformer encoder<br/>BERT / RoBERTa / custom]
+  Encoder --> Pool[Pooling<br/>mean / CLS / weighted]
+  Pool --> Project[Linear projection<br/>optional dimension reduction]
   Project --> Norm[L2 normalisation]
-  Norm --> Vector[Embedding vector\ne.g. 1536-dim float32]
+  Norm --> Vector[Embedding vector<br/>e.g. 1536-dim float32]
 ```
 
 **Tokenize:** text is split into subword tokens. **Encode:** a transformer processes all tokens in parallel, producing contextual token representations. **Pool:** token representations are aggregated into a single sentence vector (mean pooling is most common for sentence embeddings). **Project:** an optional linear layer reduces the dimension (e.g. 768→256 for MRL truncation). **Normalise:** L2 normalisation enables cosine similarity as a dot product.

--- a/next/content/docs/en/embeddings/late-interaction-colbert.mdx
+++ b/next/content/docs/en/embeddings/late-interaction-colbert.mdx
@@ -20,13 +20,13 @@ In 2025, **Jina ColBERT v2** extended late interaction to 89 languages with MRL 
 
 ```mermaid
 flowchart LR
-  Query[User query\n"best hotels near\n river AND rooftop"] --> QEnc[Query encoder\nfine-tuned BERT]
-  QEnc -->|Q matrix\n32 × 128| MaxSim
+  Query[User query<br/>"best hotels near<br/> river AND rooftop"] --> QEnc[Query encoder<br/>fine-tuned BERT]
+  QEnc -->|Q matrix<br/>32 × 128| MaxSim
 
-  Doc[Document\n512 tokens] --> DEnc[Document encoder\nshared BERT weights]
-  DEnc -->|D matrix\n512 × 128| MaxSim
+  Doc[Document<br/>512 tokens] --> DEnc[Document encoder<br/>shared BERT weights]
+  DEnc -->|D matrix<br/>512 × 128| MaxSim
 
-  MaxSim[MaxSim operator\nfor each q_i: max over d_j sim q_i·d_j\nsum all q scores] --> Score[Relevance score]
+  MaxSim[MaxSim operator<br/>for each q_i: max over d_j sim q_i·d_j<br/>sum all q scores] --> Score[Relevance score]
   Score --> Rank[Ranked results]
 ```
 

--- a/next/content/docs/en/evals/eval-frameworks.mdx
+++ b/next/content/docs/en/evals/eval-frameworks.mdx
@@ -17,7 +17,7 @@ Choosing the right framework depends on what you are evaluating: a prompt templa
 
 ```mermaid
 flowchart LR
-  TestCases[Test cases\nprompts + expected outputs] --> Framework[Eval framework]
+  TestCases[Test cases<br/>prompts + expected outputs] --> Framework[Eval framework]
   Framework -->|run inference| App[LLM application]
   App -->|outputs| Scorer[Metric scorers]
   Scorer -->|rule-based| Rules[Exact match / regex / JSON schema]

--- a/next/content/docs/en/evals/llm-as-judge.mdx
+++ b/next/content/docs/en/evals/llm-as-judge.mdx
@@ -22,7 +22,7 @@ Three dominant patterns have emerged:
 
 ```mermaid
 flowchart LR
-  Prompt[Evaluation prompt\nrubric + candidate output] --> Judge[Judge LLM]
+  Prompt[Evaluation prompt<br/>rubric + candidate output] --> Judge[Judge LLM]
   Judge -->|chain-of-thought reasoning| CoT[Reasoning trace]
   CoT -->|numeric score or verdict| Score[Score / ranking]
   Score --> Aggregator[Score aggregator]

--- a/next/content/docs/en/frameworks/index.mdx
+++ b/next/content/docs/en/frameworks/index.mdx
@@ -22,10 +22,10 @@ flowchart TD
   Task{What is your primary goal?} -->|Research and rapid iteration| PT[PyTorch]
   Task -->|Production pipelines, mobile, TPUs| TF[TensorFlow / Keras]
 
-  PT -->|Training| HF[HuggingFace Transformers\ntorchvision · torchaudio]
+  PT -->|Training| HF[HuggingFace Transformers<br/>torchvision · torchaudio]
   PT -->|Deployment| PTD[TorchScript · ONNX · PyTorch Mobile]
 
-  TF -->|Training| KR[Keras API\ntf.data · tf.distribute]
+  TF -->|Training| KR[Keras API<br/>tf.data · tf.distribute]
   TF -->|Deployment| TFD[TF Serving · TFLite · TFX · TF Hub]
 
   HF -->|Ship to production| PTD

--- a/next/content/docs/en/inference-optimization/index.mdx
+++ b/next/content/docs/en/inference-optimization/index.mdx
@@ -31,7 +31,7 @@ flowchart TD
   GPU -->|KV pages| PagedKV[Paged KV cache pool]
   PagedKV -->|prefix hit| PrefixCache[Prefix cache reuse]
   PagedKV -->|new tokens| Allocate[Allocate new blocks]
-  GPU -->|draft tokens| SpecDec[Speculative decoding\ndraft model]
+  GPU -->|draft tokens| SpecDec[Speculative decoding<br/>draft model]
   SpecDec -->|verify in parallel| GPU
   GPU --> Output[Token stream]
 ```

--- a/next/content/docs/en/inference-optimization/kv-cache.mdx
+++ b/next/content/docs/en/inference-optimization/kv-cache.mdx
@@ -20,8 +20,8 @@ The trade-off is memory: the KV cache grows linearly with context length, batch 
 
 ```mermaid
 flowchart LR
-  Prefill[Prefill phase\ncompute K,V for all prompt tokens\nstore in KV cache] --> Decode
-  Decode[Decode phase\ncompute K,V for new token only\nlook up all prior K,V from cache] -->|next token| Decode
+  Prefill[Prefill phase<br/>compute K,V for all prompt tokens<br/>store in KV cache] --> Decode
+  Decode[Decode phase<br/>compute K,V for new token only<br/>look up all prior K,V from cache] -->|next token| Decode
   Decode -->|sequence complete| Evict[Evict blocks from pool]
 ```
 

--- a/next/content/docs/en/inference-optimization/speculative-decoding.mdx
+++ b/next/content/docs/en/inference-optimization/speculative-decoding.mdx
@@ -19,8 +19,8 @@ Speculative decoding is **lossless by design**: it never changes the output dist
 
 ```mermaid
 flowchart LR
-  Prompt[Prompt\n+ context] -->|k forward passes| Draft[Draft model\nproposes tokens t1...tk]
-  Draft -->|t1 t2 t3 t4| Target[Target model\nverifies all 4 in one pass]
+  Prompt[Prompt<br/>+ context] -->|k forward passes| Draft[Draft model<br/>proposes tokens t1...tk]
+  Draft -->|t1 t2 t3 t4| Target[Target model<br/>verifies all 4 in one pass]
   Target -->|accept t1 t2 t3| Accepted[Accept 3 tokens]
   Target -->|reject t4, resample| Resampled[Resample t4 from target]
   Accepted & Resampled --> Output[Output: 4 tokens in ~2 target passes]

--- a/next/content/docs/en/inference-optimization/vllm.mdx
+++ b/next/content/docs/en/inference-optimization/vllm.mdx
@@ -21,8 +21,8 @@ Traditional attention implementations require a contiguous memory region for eac
 
 ```mermaid
 flowchart LR
-  Seq1[Sequence A\nblock table: 0→3, 1→7] -->|lookup| Pool[Physical KV block pool\n0 1 2 3 4 5 6 7 ...]
-  Seq2[Sequence B\nblock table: 0→1, 1→5] -->|lookup| Pool
+  Seq1[Sequence A<br/>block table: 0→3, 1→7] -->|lookup| Pool[Physical KV block pool<br/>0 1 2 3 4 5 6 7 ...]
+  Seq2[Sequence B<br/>block table: 0→1, 1→5] -->|lookup| Pool
   Seq3[Sequence C prefix shared] -->|copy-on-write| Pool
 ```
 

--- a/next/content/docs/en/infrastructure/index.mdx
+++ b/next/content/docs/en/infrastructure/index.mdx
@@ -19,11 +19,11 @@ The scale of infrastructure needed is driven primarily by [LLMs](/docs/llms) and
 
 ```mermaid
 flowchart LR
-  Data["Training data\n(object store / NFS)"] -->|"tf.data / DataLoader"| Preprocess["Data preprocessing\n(tokenization, augmentation)"]
-  Config["Model config\n(hyperparameters)"] -->|"defines"| TrainJob["Distributed training job\n(SLURM / K8s / cloud)"]
+  Data["Training data<br/>(object store / NFS)"] -->|"tf.data / DataLoader"| Preprocess["Data preprocessing<br/>(tokenization, augmentation)"]
+  Config["Model config<br/>(hyperparameters)"] -->|"defines"| TrainJob["Distributed training job<br/>(SLURM / K8s / cloud)"]
   Preprocess -->|"batches"| TrainJob
-  TrainJob -->|"data parallel\nor model parallel"| GPUCluster["GPU / TPU cluster"]
-  GPUCluster -->|"checkpoints"| Storage["Model checkpoint\n(S3 / GCS / NFS)"]
+  TrainJob -->|"data parallel<br/>or model parallel"| GPUCluster["GPU / TPU cluster"]
+  GPUCluster -->|"checkpoints"| Storage["Model checkpoint<br/>(S3 / GCS / NFS)"]
   Storage -->|"best checkpoint"| Model["Final model weights"]
 ```
 
@@ -31,7 +31,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  Model["Model weights"] -->|"load + quantize"| InferenceServer["Inference server\n(vLLM / TGI / TF Serving)"]
+  Model["Model weights"] -->|"load + quantize"| InferenceServer["Inference server<br/>(vLLM / TGI / TF Serving)"]
   Request["Incoming request"] -->|"route"| LoadBalancer["Load balancer"]
   LoadBalancer -->|"dispatch"| InferenceServer
   InferenceServer -->|"continuous batching"| GPU["Inference GPU"]

--- a/next/content/docs/en/knowledge-distillation/index.mdx
+++ b/next/content/docs/en/knowledge-distillation/index.mdx
@@ -19,12 +19,12 @@ Knowledge distillation is complementary to [quantization](/docs/quantization) an
 
 ```mermaid
 flowchart LR
-  TrainData["Training data"] -->|"forward pass"| Teacher["Teacher model\n(large, frozen)"]
-  Teacher -->|"soft logits\n(temperature T)"| SoftLabels["Soft labels\n(probability distribution)"]
-  TrainData -->|"ground truth"| HardLabels["Hard labels\n(one-hot)"]
+  TrainData["Training data"] -->|"forward pass"| Teacher["Teacher model<br/>(large, frozen)"]
+  Teacher -->|"soft logits<br/>(temperature T)"| SoftLabels["Soft labels<br/>(probability distribution)"]
+  TrainData -->|"ground truth"| HardLabels["Hard labels<br/>(one-hot)"]
   SoftLabels -->|"KL divergence loss"| Loss["Combined distillation loss"]
   HardLabels -->|"cross-entropy loss"| Loss
-  Loss -->|"backprop"| Student["Student model\n(small, trainable)"]
+  Loss -->|"backprop"| Student["Student model<br/>(small, trainable)"]
   Student -->|"converges"| Deployed["Deployed student"]
 ```
 

--- a/next/content/docs/en/llms/post-training.mdx
+++ b/next/content/docs/en/llms/post-training.mdx
@@ -77,7 +77,7 @@ This eliminates the critic (value function) entirely — the group statistics se
 ```mermaid
 flowchart TD
   P[Prompt] --> S[Sample group of N responses]
-  S --> R[Score each with verifiable reward\ne.g. math checker / code runner]
+  S --> R[Score each with verifiable reward<br/>e.g. math checker / code runner]
   R --> A[Compute group-normalized advantages]
   A --> G[Clipped policy gradient update]
   G --> P2[Updated policy]
@@ -101,9 +101,9 @@ DAPO enables stable training at scales where GRPO diverges, and has been adopted
 
 ```mermaid
 flowchart LR
-  PT[Pretrained base model] --> SFT[SFT\nInstruction format]
-  SFT --> PREF[Preference optimization\nRLHF · DPO · ORPO]
-  PREF --> RLVR[RL with verifiable rewards\nGRPO · DAPO]
+  PT[Pretrained base model] --> SFT[SFT<br/>Instruction format]
+  SFT --> PREF[Preference optimization<br/>RLHF · DPO · ORPO]
+  PREF --> RLVR[RL with verifiable rewards<br/>GRPO · DAPO]
   RLVR --> Final[Aligned + reasoning model]
 ```
 

--- a/next/content/docs/en/local-inference/index.mdx
+++ b/next/content/docs/en/local-inference/index.mdx
@@ -19,9 +19,9 @@ Local inference is not a single technology but a stack: model weights (GGUF, Saf
 
 ```mermaid
 flowchart LR
-  Hub["Model Hub\n(HuggingFace, Ollama registry)"] -->|"download weights"| Weights["Model weights\n(GGUF / SafeTensors)"]
-  Weights -->|"load + memory map"| Runtime["Inference runtime\n(llama.cpp / vLLM / TFLite)"]
-  Quantize["Quantization layer\n(INT4/INT8 via GPTQ/AWQ)"] -->|"reduces memory"| Runtime
+  Hub["Model Hub<br/>(HuggingFace, Ollama registry)"] -->|"download weights"| Weights["Model weights<br/>(GGUF / SafeTensors)"]
+  Weights -->|"load + memory map"| Runtime["Inference runtime<br/>(llama.cpp / vLLM / TFLite)"]
+  Quantize["Quantization layer<br/>(INT4/INT8 via GPTQ/AWQ)"] -->|"reduces memory"| Runtime
   Prompt["Prompt / request"] -->|"tokenize"| Runtime
   Runtime -->|"forward pass on hardware"| Hardware["CPU / GPU / NPU / Apple Silicon"]
   Hardware -->|"generated tokens"| Output["Output / stream"]

--- a/next/content/docs/en/mcp/building-clients.mdx
+++ b/next/content/docs/en/mcp/building-clients.mdx
@@ -42,7 +42,7 @@ The transport choice depends on where the server runs. **stdio transport** (`Std
 flowchart LR
   HostApp["Host Application"]
   Client["MCP Client"]
-  Transport["Transport Layer\n(stdio or HTTP/SSE)"]
+  Transport["Transport Layer<br/>(stdio or HTTP/SSE)"]
   Server["MCP Server"]
 
   HostApp -->|"1. create client + connect"| Client

--- a/next/content/docs/en/mcp/building-servers.mdx
+++ b/next/content/docs/en/mcp/building-servers.mdx
@@ -44,10 +44,10 @@ The transport layer determines how the server communicates with clients. **stdio
 flowchart TB
   Client["MCP Client"]
   Server["MCP Server Process"]
-  ToolReg["Tool Registry\n(get_forecast, read_file, ...)"]
-  ResourceReg["Resource Registry\n(file:///, db:///...)"]
-  PromptReg["Prompt Registry\n(query_builder, summarize, ...)"]
-  External["External Systems\n(APIs, DBs, File System)"]
+  ToolReg["Tool Registry<br/>(get_forecast, read_file, ...)"]
+  ResourceReg["Resource Registry<br/>(file:///, db:///...)"]
+  PromptReg["Prompt Registry<br/>(query_builder, summarize, ...)"]
+  External["External Systems<br/>(APIs, DBs, File System)"]
 
   Client -->|"initialize handshake"| Server
   Server -->|"capabilities response"| Client

--- a/next/content/docs/en/mcp/index.mdx
+++ b/next/content/docs/en/mcp/index.mdx
@@ -24,13 +24,13 @@ MCP follows a strict client-server model with three distinct roles. The **host a
 
 ```mermaid
 flowchart LR
-  HostApp["Host Application\n(AI App / Agent)"]
+  HostApp["Host Application<br/>(AI App / Agent)"]
   Client1["MCP Client A"]
   Client2["MCP Client B"]
-  Server1["MCP Server A\n(File System)"]
-  Server2["MCP Server B\n(Weather API)"]
-  Tools1["Tools / Resources\n(read_file, list_dir)"]
-  Tools2["Tools / Resources\n(get_forecast, get_alerts)"]
+  Server1["MCP Server A<br/>(File System)"]
+  Server2["MCP Server B<br/>(Weather API)"]
+  Tools1["Tools / Resources<br/>(read_file, list_dir)"]
+  Tools2["Tools / Resources<br/>(get_forecast, get_alerts)"]
 
   HostApp -->|"embeds"| Client1
   HostApp -->|"embeds"| Client2

--- a/next/content/docs/en/mlops/cicd/dvc.mdx
+++ b/next/content/docs/en/mlops/cicd/dvc.mdx
@@ -19,11 +19,11 @@ DVC integrates tightly with Git workflows. A `dvc.lock` file, committed to Git, 
 
 ```mermaid
 flowchart LR
-  Code["Code & Config\n(Git)"] -->|"dvc repro"| Pipeline["DVC Pipeline\n(dvc.yaml)"]
+  Code["Code & Config<br/>(Git)"] -->|"dvc repro"| Pipeline["DVC Pipeline<br/>(dvc.yaml)"]
   Pipeline -->|"runs stage"| Train["Training Stage"]
-  Train -->|"produces artifact"| Artifact["model artifact\n(local cache)"]
-  Artifact -->|"dvc push"| Remote["Remote Storage\n(S3 / GCS / Azure)"]
-  Remote -->|"dvc pull"| Colleague["Colleague's machine\nor CI runner"]
+  Train -->|"produces artifact"| Artifact["model artifact<br/>(local cache)"]
+  Artifact -->|"dvc push"| Remote["Remote Storage<br/>(S3 / GCS / Azure)"]
+  Remote -->|"dvc pull"| Colleague["Colleague's machine<br/>or CI runner"]
   Artifact -->|"pointer .dvc file"| Git["Git repository"]
   Git -->|"git checkout"| Colleague
 ```

--- a/next/content/docs/en/mlops/cicd/model-registry.mdx
+++ b/next/content/docs/en/mlops/cicd/model-registry.mdx
@@ -19,10 +19,10 @@ Model registries integrate with both the training side (experiment trackers log 
 
 ```mermaid
 flowchart LR
-  Experiment["Training Run\n(MLflow / W&B)"] -->|"log + register artifact"| Registry["Model Registry\n(versioned catalog)"]
-  Registry -->|"promote to Staging"| Staging["Staging Environment\n(shadow traffic / A/B)"]
+  Experiment["Training Run<br/>(MLflow / W&B)"] -->|"log + register artifact"| Registry["Model Registry<br/>(versioned catalog)"]
+  Registry -->|"promote to Staging"| Staging["Staging Environment<br/>(shadow traffic / A/B)"]
   Staging -->|"approval / quality gate"| Production["Production Deployment"]
-  Production -->|"new version available"| Archived["Archived\n(old version)"]
+  Production -->|"new version available"| Archived["Archived<br/>(old version)"]
   CI["CI/CD Pipeline"] -->|"fetch latest Production model"| Production
   Registry -->|"webhook / event"| CI
 ```

--- a/next/content/docs/en/mlops/data-engineering/airflow.mdx
+++ b/next/content/docs/en/mlops/data-engineering/airflow.mdx
@@ -35,12 +35,12 @@ The Airflow scheduler is a Python process that parses DAG files on a configurabl
 
 ```mermaid
 flowchart LR
-  DagFile["DAG file\n(Python)"] -- "parsed by" --> Scheduler["Scheduler"]
-  Scheduler -- "dispatches task" --> Executor["Executor\n(Celery / K8s)"]
+  DagFile["DAG file<br/>(Python)"] -- "parsed by" --> Scheduler["Scheduler"]
+  Scheduler -- "dispatches task" --> Executor["Executor<br/>(Celery / K8s)"]
   Executor -- "runs on" --> Worker["Worker / Pod"]
-  Worker -- "writes state" --> MetaDB["Metadata DB\n(PostgreSQL)"]
+  Worker -- "writes state" --> MetaDB["Metadata DB<br/>(PostgreSQL)"]
   MetaDB -- "read by" --> WebUI["Web UI"]
-  Worker -- "logs" --> LogStore["Log store\n(S3 / GCS)"]
+  Worker -- "logs" --> LogStore["Log store<br/>(S3 / GCS)"]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/mlops/data-engineering/index.mdx
+++ b/next/content/docs/en/mlops/data-engineering/index.mdx
@@ -31,10 +31,10 @@ Data quality checks should be embedded at every stage of the pipeline, not bolte
 
 ```mermaid
 flowchart LR
-  Sources["Sources\n(DB / API / Events)"] -- "raw records" --> Ingest["Ingest\n(Extract & Load)"]
-  Ingest -- "raw data" --> Transform["Transform\n(Clean / Validate / Feature eng.)"]
-  Transform -- "validated features" --> Store["Store\n(Warehouse / Feature store)"]
-  Store -- "query / serve" --> Serve["Serve\n(Training / Inference)"]
+  Sources["Sources<br/>(DB / API / Events)"] -- "raw records" --> Ingest["Ingest<br/>(Extract & Load)"]
+  Ingest -- "raw data" --> Transform["Transform<br/>(Clean / Validate / Feature eng.)"]
+  Transform -- "validated features" --> Store["Store<br/>(Warehouse / Feature store)"]
+  Store -- "query / serve" --> Serve["Serve<br/>(Training / Inference)"]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/mlops/data-engineering/kafka.mdx
+++ b/next/content/docs/en/mlops/data-engineering/kafka.mdx
@@ -35,12 +35,12 @@ Kafka is typically positioned between raw event sources and downstream ML system
 
 ```mermaid
 flowchart LR
-  Producer["Producer\n(App / IoT / DB CDC)"] -- "publish events" --> Topic["Kafka Topic\n(partitioned, replicated)"]
-  Topic -- "consume raw events" --> StreamProcessor["Stream Processor\n(Spark / Flink / Kafka Streams)"]
-  StreamProcessor -- "write features" --> FeatureStore["Online Feature Store\n(Feast / Redis)"]
-  FeatureStore -- "low-latency read" --> ModelServer["Model Server\n(REST / gRPC)"]
+  Producer["Producer<br/>(App / IoT / DB CDC)"] -- "publish events" --> Topic["Kafka Topic<br/>(partitioned, replicated)"]
+  Topic -- "consume raw events" --> StreamProcessor["Stream Processor<br/>(Spark / Flink / Kafka Streams)"]
+  StreamProcessor -- "write features" --> FeatureStore["Online Feature Store<br/>(Feast / Redis)"]
+  FeatureStore -- "low-latency read" --> ModelServer["Model Server<br/>(REST / gRPC)"]
   ModelServer -- "publish predictions" --> PredictionTopic["Prediction Topic"]
-  PredictionTopic -- "consume" --> Consumer["Consumer\n(Monitoring / Downstream app)"]
+  PredictionTopic -- "consume" --> Consumer["Consumer<br/>(Monitoring / Downstream app)"]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/mlops/data-engineering/spark.mdx
+++ b/next/content/docs/en/mlops/data-engineering/spark.mdx
@@ -35,11 +35,11 @@ A Spark application has one **driver** process and one or more **executor** proc
 
 ```mermaid
 flowchart LR
-  UserCode["User code\n(PySpark)"] -- "submits application" --> Driver["Driver\n(SparkContext)"]
-  Driver -- "requests resources" --> ClusterManager["Cluster Manager\n(YARN / K8s)"]
-  ClusterManager -- "allocates" --> Executors["Executors\n(Worker nodes)"]
+  UserCode["User code<br/>(PySpark)"] -- "submits application" --> Driver["Driver<br/>(SparkContext)"]
+  Driver -- "requests resources" --> ClusterManager["Cluster Manager<br/>(YARN / K8s)"]
+  ClusterManager -- "allocates" --> Executors["Executors<br/>(Worker nodes)"]
   Driver -- "sends tasks" --> Executors
-  Executors -- "read / write data" --> Storage["Storage\n(HDFS / S3 / Delta)"]
+  Executors -- "read / write data" --> Storage["Storage<br/>(HDFS / S3 / Delta)"]
   Executors -- "return results" --> Driver
 ```
 

--- a/next/content/docs/en/mlops/deployment/kubeflow.mdx
+++ b/next/content/docs/en/mlops/deployment/kubeflow.mdx
@@ -19,15 +19,15 @@ KubeFlow's strength is that it runs on any Kubernetes cluster — on-premises, G
 
 ```mermaid
 flowchart TB
-  Developer["Data Scientist\n(Jupyter / SDK)"] -->|"define pipeline"| KFP["KubeFlow Pipelines\n(KFP)"]
-  KFP -->|"schedules pods"| K8s["Kubernetes\n(control plane)"]
-  K8s -->|"run training job"| TrainPod["Training Pod\n(GPU node pool)"]
-  TrainPod -->|"log metrics"| Katib["Katib\n(hyperparameter tuning)"]
+  Developer["Data Scientist<br/>(Jupyter / SDK)"] -->|"define pipeline"| KFP["KubeFlow Pipelines<br/>(KFP)"]
+  KFP -->|"schedules pods"| K8s["Kubernetes<br/>(control plane)"]
+  K8s -->|"run training job"| TrainPod["Training Pod<br/>(GPU node pool)"]
+  TrainPod -->|"log metrics"| Katib["Katib<br/>(hyperparameter tuning)"]
   Katib -->|"suggest next trial"| TrainPod
-  TrainPod -->|"push artifact"| Storage["Model Store\n(S3 / GCS / MinIO)"]
-  Storage -->|"register model"| KFServe["KServe\n(model serving)"]
+  TrainPod -->|"push artifact"| Storage["Model Store<br/>(S3 / GCS / MinIO)"]
+  Storage -->|"register model"| KFServe["KServe<br/>(model serving)"]
   KFServe -->|"expose endpoint"| Client["Prediction Clients"]
-  KFP -->|"emit events"| Dashboard["KubeFlow Dashboard\n(UI + RBAC)"]
+  KFP -->|"emit events"| Dashboard["KubeFlow Dashboard<br/>(UI + RBAC)"]
 ```
 
 ### KubeFlow Pipelines (KFP)

--- a/next/content/docs/en/mlops/deployment/ml-kubernetes.mdx
+++ b/next/content/docs/en/mlops/deployment/ml-kubernetes.mdx
@@ -19,15 +19,15 @@ The key difference from running ML on bare VMs is that Kubernetes provides decla
 
 ```mermaid
 flowchart TB
-  Developer["Data Scientist\n(writes Dockerfile + YAML)"] -->|"docker build + push"| Registry["Container Registry\n(ECR / GCR / GHCR)"]
+  Developer["Data Scientist<br/>(writes Dockerfile + YAML)"] -->|"docker build + push"| Registry["Container Registry<br/>(ECR / GCR / GHCR)"]
   Registry -->|"image pull"| K8s["Kubernetes Cluster"]
-  K8s -->|"schedule on GPU node"| TrainJob["Training Job\n(K8s Job)"]
-  K8s -->|"scale replicas"| ServingDeploy["Serving Deployment\n(K8s Deployment + HPA)"]
+  K8s -->|"schedule on GPU node"| TrainJob["Training Job<br/>(K8s Job)"]
+  K8s -->|"scale replicas"| ServingDeploy["Serving Deployment<br/>(K8s Deployment + HPA)"]
   ServingDeploy -->|"expose externally"| Ingress["Ingress / LoadBalancer"]
   Ingress -->|"traffic"| Client["Client"]
-  TrainJob -->|"write artifacts"| PVC["Persistent Volume\nor Object Storage"]
+  TrainJob -->|"write artifacts"| PVC["Persistent Volume<br/>or Object Storage"]
   PVC -->|"model load"| ServingDeploy
-  K8s -->|"GPU request"| GPUNode["GPU Node Pool\n(nvidia.com/gpu resource)"]
+  K8s -->|"GPU request"| GPUNode["GPU Node Pool<br/>(nvidia.com/gpu resource)"]
 ```
 
 ### Containerizing ML models

--- a/next/content/docs/en/mlops/deployment/model-serving.mdx
+++ b/next/content/docs/en/mlops/deployment/model-serving.mdx
@@ -19,14 +19,14 @@ Scaling a model serving system involves challenges that are specific to ML: mode
 
 ```mermaid
 flowchart LR
-  Client["Client\n(mobile / web / service)"] -->|"HTTPS request"| Gateway["API Gateway\n(rate limit, auth)"]
-  Gateway -->|"route request"| Server["Model Server\n(TorchServe / Triton / BentoML)"]
-  Server -->|"load model"| Store["Model Store\n(S3 / registry)"]
-  Server -->|"batched GPU calls"| GPU["GPU / CPU\n(inference worker)"]
+  Client["Client<br/>(mobile / web / service)"] -->|"HTTPS request"| Gateway["API Gateway<br/>(rate limit, auth)"]
+  Gateway -->|"route request"| Server["Model Server<br/>(TorchServe / Triton / BentoML)"]
+  Server -->|"load model"| Store["Model Store<br/>(S3 / registry)"]
+  Server -->|"batched GPU calls"| GPU["GPU / CPU<br/>(inference worker)"]
   GPU -->|"prediction"| Server
   Server -->|"JSON response"| Gateway
   Gateway -->|"response"| Client
-  Server -->|"metrics"| Monitor["Monitoring\n(latency, throughput)"]
+  Server -->|"metrics"| Monitor["Monitoring<br/>(latency, throughput)"]
 ```
 
 ### Batch inference

--- a/next/content/docs/en/mlops/feature-stores.mdx
+++ b/next/content/docs/en/mlops/feature-stores.mdx
@@ -39,13 +39,13 @@ Materialization is the process of running transformation pipelines and writing r
 
 ```mermaid
 flowchart LR
-  RawData[Raw data sources\nDB / data lake / streams] -->|"batch ETL"| OfflineStore[(Offline store\nBigQuery / S3 Parquet)]
-  RawData -->|"stream pipeline"| OnlineStore[(Online store\nRedis / DynamoDB)]
+  RawData[Raw data sources<br/>DB / data lake / streams] -->|"batch ETL"| OfflineStore[(Offline store<br/>BigQuery / S3 Parquet)]
+  RawData -->|"stream pipeline"| OnlineStore[(Online store<br/>Redis / DynamoDB)]
   OfflineStore -->|"point-in-time join"| TrainingData[Training dataset]
   TrainingData -->|"train model"| Model[ML model]
   OnlineStore -->|"low-latency lookup"| Serving[Inference serving]
   Model -->|"deploy"| Serving
-  FeatureDefs[Feature definitions\nPython / YAML] -->|"define transforms"| OfflineStore
+  FeatureDefs[Feature definitions<br/>Python / YAML] -->|"define transforms"| OfflineStore
   FeatureDefs -->|"define transforms"| OnlineStore
 ```
 

--- a/next/content/docs/en/mlops/iac/ansible.mdx
+++ b/next/content/docs/en/mlops/iac/ansible.mdx
@@ -40,13 +40,13 @@ Ansible modules are designed to be idempotent: running a playbook multiple times
 
 ```mermaid
 flowchart LR
-  ControlNode[Control node\nAnsible CLI] -->|"parse inventory"| Inventory[Inventory\nstatic / dynamic]
-  Inventory -->|"resolve target hosts"| Hosts[Target hosts\nGPU training nodes]
-  ControlNode -->|"read playbook"| Playbook[Playbook\n.yml tasks & roles]
+  ControlNode[Control node<br/>Ansible CLI] -->|"parse inventory"| Inventory[Inventory<br/>static / dynamic]
+  Inventory -->|"resolve target hosts"| Hosts[Target hosts<br/>GPU training nodes]
+  ControlNode -->|"read playbook"| Playbook[Playbook<br/>.yml tasks & roles]
   Playbook -->|"SSH connection"| Hosts
-  Hosts -->|"execute modules"| Tasks[Task execution\ninstall CUDA, pip, config]
-  Tasks -->|"notify on change"| Handlers[Handlers\nrestart services]
-  Tasks -->|"report status"| Summary[Run summary\nok / changed / failed]
+  Hosts -->|"execute modules"| Tasks[Task execution<br/>install CUDA, pip, config]
+  Tasks -->|"notify on change"| Handlers[Handlers<br/>restart services]
+  Tasks -->|"report status"| Summary[Run summary<br/>ok / changed / failed]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/mlops/iac/terraform.mdx
+++ b/next/content/docs/en/mlops/iac/terraform.mdx
@@ -36,11 +36,11 @@ Running `terraform init` downloads required providers and modules and initialize
 
 ```mermaid
 flowchart LR
-  HCL[HCL configuration\n.tf files] -->|"terraform init"| Init[Provider & module\ndownload]
-  Init -->|"terraform plan"| Plan[Execution plan\ndiff against state]
+  HCL[HCL configuration<br/>.tf files] -->|"terraform init"| Init[Provider & module<br/>download]
+  Init -->|"terraform plan"| Plan[Execution plan<br/>diff against state]
   Plan -->|"human review / CI approval"| Apply[terraform apply]
-  Apply -->|"API calls"| Cloud[Cloud provider APIs\nAWS / GCP / Azure]
-  Cloud -->|"resource IDs"| State[State file\nS3 / GCS backend]
+  Apply -->|"API calls"| Cloud[Cloud provider APIs<br/>AWS / GCP / Azure]
+  Cloud -->|"resource IDs"| State[State file<br/>S3 / GCS backend]
   State -->|"next plan reads state"| Plan
 ```
 

--- a/next/content/docs/en/mlops/mlflow.mdx
+++ b/next/content/docs/en/mlops/mlflow.mdx
@@ -36,8 +36,8 @@ The registry stores named model versions with transition states. Automated CI/CD
 ```mermaid
 flowchart LR
   Code[Training code] -->|"mlflow.start_run()"| Run[Active run]
-  Run -->|"log_params / log_metrics"| Backend[(Backend store\nSQLite / Postgres)]
-  Run -->|"log_artifact / log_model"| ArtStore[(Artifact store\nS3 / GCS / local)]
+  Run -->|"log_params / log_metrics"| Backend[(Backend store<br/>SQLite / Postgres)]
+  Run -->|"log_artifact / log_model"| ArtStore[(Artifact store<br/>S3 / GCS / local)]
   Backend -->|"query"| UI[MLflow UI]
   ArtStore -->|"retrieve"| UI
   UI -->|"register_model"| Registry[Model Registry]

--- a/next/content/docs/en/mlops/monitoring/grafana.mdx
+++ b/next/content/docs/en/mlops/monitoring/grafana.mdx
@@ -40,12 +40,12 @@ Grafana supports declarative provisioning of data sources, dashboards, and alert
 
 ```mermaid
 flowchart LR
-  PrometheusDS[Prometheus\ndata source] -->|"PromQL query"| GrafanaQuery[Grafana query engine]
-  SQLDB[SQL / InfluxDB\ndata source] -->|"SQL / Flux query"| GrafanaQuery
-  GrafanaQuery -->|"normalized data frames"| Panels[Dashboard panels\ntime series, gauges, tables]
-  Panels -->|"rendered in browser"| Users[Data scientists /\nML engineers]
+  PrometheusDS[Prometheus<br/>data source] -->|"PromQL query"| GrafanaQuery[Grafana query engine]
+  SQLDB[SQL / InfluxDB<br/>data source] -->|"SQL / Flux query"| GrafanaQuery
+  GrafanaQuery -->|"normalized data frames"| Panels[Dashboard panels<br/>time series, gauges, tables]
+  Panels -->|"rendered in browser"| Users[Data scientists /<br/>ML engineers]
   GrafanaQuery -->|"evaluate alert rule"| AlertEngine[Grafana alert engine]
-  AlertEngine -->|"route notification"| ContactPoints[Slack / PagerDuty /\nemail]
+  AlertEngine -->|"route notification"| ContactPoints[Slack / PagerDuty /<br/>email]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/mlops/monitoring/prometheus.mdx
+++ b/next/content/docs/en/mlops/monitoring/prometheus.mdx
@@ -40,8 +40,8 @@ For multi-cluster or long-retention scenarios, Prometheus remote-writes samples 
 
 ```mermaid
 flowchart LR
-  Targets[Instrumented targets\nML serving / training jobs] -->|"HTTP scrape /metrics"| Scrape[Prometheus scrape engine]
-  Scrape -->|"write samples"| TSDB[Time-series database\nlocal TSDB]
+  Targets[Instrumented targets<br/>ML serving / training jobs] -->|"HTTP scrape /metrics"| Scrape[Prometheus scrape engine]
+  Scrape -->|"write samples"| TSDB[Time-series database<br/>local TSDB]
   TSDB -->|"evaluate PromQL rules"| AlertRules[Alerting rules engine]
   AlertRules -->|"fire alert"| Alertmanager[Alertmanager]
   Alertmanager -->|"route notification"| Receivers[Slack / PagerDuty / email]

--- a/next/content/docs/en/model-compression/index.mdx
+++ b/next/content/docs/en/model-compression/index.mdx
@@ -19,10 +19,10 @@ Compression is applied at different stages: **post-training** (applied after tra
 
 ```mermaid
 flowchart LR
-  Large["Large model\n(FP32 / FP16)"] -->|"identify targets"| Analysis["Sensitivity analysis\n(which layers to compress)"]
-  Analysis -->|"apply"| Prune["Pruning\n(remove weights / channels)"]
-  Analysis -->|"apply"| Quant["Quantization\n(INT8 / INT4)"]
-  Analysis -->|"train student"| Distill["Knowledge distillation\n(student mimics teacher)"]
+  Large["Large model<br/>(FP32 / FP16)"] -->|"identify targets"| Analysis["Sensitivity analysis<br/>(which layers to compress)"]
+  Analysis -->|"apply"| Prune["Pruning<br/>(remove weights / channels)"]
+  Analysis -->|"apply"| Quant["Quantization<br/>(INT8 / INT4)"]
+  Analysis -->|"train student"| Distill["Knowledge distillation<br/>(student mimics teacher)"]
   Prune -->|"fine-tune"| Small["Compressed model"]
   Quant -->|"calibrate"| Small
   Distill -->|"student training"| Small

--- a/next/content/docs/en/model-providers/anthropic.mdx
+++ b/next/content/docs/en/model-providers/anthropic.mdx
@@ -32,7 +32,7 @@ The Messages API (`POST /v1/messages`) is Anthropic's primary interface. Unlike 
 ```mermaid
 flowchart LR
   Client[Client app] -->|POST /v1/messages| API[Anthropic API]
-  API -->|system + messages| Selector{Model\nselector}
+  API -->|system + messages| Selector{Model<br/>selector}
   Selector -->|complex reasoning| Opus[Claude Opus 4.7]
   Selector -->|balanced| Sonnet[Claude Sonnet 4.6]
   Selector -->|fast / cheap| Haiku[Claude Haiku 4.5]
@@ -40,7 +40,7 @@ flowchart LR
   Sonnet --> Resp
   Haiku --> Resp
   Resp --> Client
-  Resp -.->|token usage,\nbilling| Platform[Anthropic platform]
+  Resp -.->|token usage,<br/>billing| Platform[Anthropic platform]
 ```
 
 ### Tool use
@@ -50,8 +50,8 @@ Tool use lets Claude call external functions by emitting structured `tool_use` c
 ```mermaid
 flowchart LR
   UserMsg[User message] --> Claude[Claude model]
-  Claude -->|emits tool_use block| ToolReq[Tool request\nname + input JSON]
-  ToolReq -->|your code invokes| ExtSystem[External system\nor function]
+  Claude -->|emits tool_use block| ToolReq[Tool request<br/>name + input JSON]
+  ToolReq -->|your code invokes| ExtSystem[External system<br/>or function]
   ExtSystem -->|result| ToolResult[tool_result message]
   ToolResult --> Claude
   Claude -->|final text response| UserMsg
@@ -73,7 +73,7 @@ Claude Opus 4.7 and Sonnet 4.6 support a 1M-token context window, and Haiku 4.5 
 
 ```mermaid
 flowchart LR
-  LargeDoc[Large document\nor codebase] -->|tokenize| Tokens[Up to 1M tokens]
+  LargeDoc[Large document<br/>or codebase] -->|tokenize| Tokens[Up to 1M tokens]
   Tokens -->|single API call| Claude[Claude model]
   SystemPrompt[System prompt] -->|cached prefix| Cache[(Prompt cache)]
   Cache -->|cache hit: 90% cheaper| Claude

--- a/next/content/docs/en/model-providers/cohere.mdx
+++ b/next/content/docs/en/model-providers/cohere.mdx
@@ -74,14 +74,14 @@ Cohere's RAG integration ties Embed, Rerank, and Command A together into a unifi
 
 ```mermaid
 flowchart LR
-  Q[User Query] -->|embed with\nsearch_query| E[Embed API]
+  Q[User Query] -->|embed with<br/>search_query| E[Embed API]
   E -->|query vector| VDB[(Vector Database)]
   VDB -->|top-k candidates| RR[Rerank API]
-  RR -->|ranked documents\nwith scores| CMD[Command A]
+  RR -->|ranked documents<br/>with scores| CMD[Command A]
   Q -->|original question| CMD
-  CMD -->|grounded answer\nwith citations| A[Response]
+  CMD -->|grounded answer<br/>with citations| A[Response]
 
-  DOCS[Documents] -->|embed with\nsearch_document| E2[Embed API]
+  DOCS[Documents] -->|embed with<br/>search_document| E2[Embed API]
   E2 -->|document vectors| VDB
 ```
 

--- a/next/content/docs/en/model-providers/deepseek.mdx
+++ b/next/content/docs/en/model-providers/deepseek.mdx
@@ -51,14 +51,14 @@ DeepSeek V4 model weights are released on Hugging Face under permissive licenses
 
 ```mermaid
 flowchart TD
-  U[User / Application] -->|OpenAI-compatible request| API[DeepSeek API\napi.deepseek.com]
-  U -->|self-hosted request| SH[Self-Hosted Inference\nvLLM / Ollama / NIM]
+  U[User / Application] -->|OpenAI-compatible request| API[DeepSeek API<br/>api.deepseek.com]
+  U -->|self-hosted request| SH[Self-Hosted Inference<br/>vLLM / Ollama / NIM]
 
   API -->|general chat + thinking| V4F[DeepSeek V4 Flash]
   API -->|higher quality + thinking| V4P[DeepSeek V4 Pro]
-  SH -->|open weights| HF[Hugging Face\nModel Weights]
+  SH -->|open weights| HF[Hugging Face<br/>Model Weights]
 
-  V4F -->|thinking mode| THINK["reasoning trace\n(chain-of-thought)"]
+  V4F -->|thinking mode| THINK["reasoning trace<br/>(chain-of-thought)"]
   THINK -->|produces| ANS[Final Answer]
   V4F -->|non-thinking mode| ANS
   V4P -->|thinking / non-thinking| ANS

--- a/next/content/docs/en/model-providers/google-gemini.mdx
+++ b/next/content/docs/en/model-providers/google-gemini.mdx
@@ -59,21 +59,21 @@ On Vertex AI, Gemini is accessed through the `vertexai` Python SDK (`aiplatform`
 
 ```mermaid
 flowchart LR
-    Dev[Developer / Application] -->|"API key or service account"| GLAPI["Generative Language API\ngenerativelanguage.googleapis.com"]
+    Dev[Developer / Application] -->|"API key or service account"| GLAPI["Generative Language API<br/>generativelanguage.googleapis.com"]
 
-    GLAPI -->|"stable / GA"| Flash[Gemini 2.5 Flash\nlow-latency / high-throughput]
-    GLAPI -->|"stable / GA"| Pro[Gemini 2.5 Pro\nbalanced / production]
-    GLAPI -->|"preview"| Pro31[Gemini 3.1 Pro Preview\nnext-gen]
+    GLAPI -->|"stable / GA"| Flash[Gemini 2.5 Flash<br/>low-latency / high-throughput]
+    GLAPI -->|"stable / GA"| Pro[Gemini 2.5 Pro<br/>balanced / production]
+    GLAPI -->|"preview"| Pro31[Gemini 3.1 Pro Preview<br/>next-gen]
 
-    Dev -->|"upload assets"| FileAPI[File API\nvideo & audio URIs]
+    Dev -->|"upload assets"| FileAPI[File API<br/>video & audio URIs]
     FileAPI -->|"file URI in request"| GLAPI
 
-    GLAPI -->|"search retrieval tool"| GSearch[Google Search\nreal-time grounding]
+    GLAPI -->|"search retrieval tool"| GSearch[Google Search<br/>real-time grounding]
     GSearch -->|"grounded results"| GLAPI
 
-    AIStudio[Google AI Studio\nprototyping] -->|"generates"| GLAPI
-    VertexAI[Vertex AI\nenterprise production] -->|"managed endpoint"| GLAPI
-    VertexAI -->|"fine-tuning pipeline"| FT[Fine-tuned model\ndeployed on Vertex]
+    AIStudio[Google AI Studio<br/>prototyping] -->|"generates"| GLAPI
+    VertexAI[Vertex AI<br/>enterprise production] -->|"managed endpoint"| GLAPI
+    VertexAI -->|"fine-tuning pipeline"| FT[Fine-tuned model<br/>deployed on Vertex]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/model-providers/meta-llama.mdx
+++ b/next/content/docs/en/model-providers/meta-llama.mdx
@@ -52,26 +52,26 @@ One of the most compelling advantages of open-weights models is full fine-tuning
 
 ```mermaid
 flowchart TD
-    Source["Meta model weights\n(Hugging Face Hub / llama.com)"] -->|"download weights"| Local
+    Source["Meta model weights<br/>(Hugging Face Hub / llama.com)"] -->|"download weights"| Local
 
     subgraph Local["Local / Self-hosted inference"]
         direction LR
-        TF["Hugging Face Transformers\n(GPU server)"]
-        LCPP["llama.cpp\n(Scout: single H100 INT4)"]
-        vLLM["vLLM\n(production serving, OpenAI-compatible API)"]
+        TF["Hugging Face Transformers<br/>(GPU server)"]
+        LCPP["llama.cpp<br/>(Scout: single H100 INT4)"]
+        vLLM["vLLM<br/>(production serving, OpenAI-compatible API)"]
     end
 
-    Source -->|"weights available for fine-tuning"| FT["Fine-tuning\n(LoRA / QLoRA / SFT)"]
+    Source -->|"weights available for fine-tuning"| FT["Fine-tuning<br/>(LoRA / QLoRA / SFT)"]
     FT -->|"merged or adapter weights"| Local
 
     Source -->|"hosted by provider"| Providers
 
     subgraph Providers["Third-party API providers"]
         direction LR
-        Together["Together AI\n(Llama 4, competitive pricing)"]
-        Groq["Groq\n(LPU hardware, ultra-low latency)"]
-        Fireworks["Fireworks AI\n(serverless, fine-tuned models)"]
-        LlamaAPI["Llama API\n(first-party, llama.com)"]
+        Together["Together AI<br/>(Llama 4, competitive pricing)"]
+        Groq["Groq<br/>(LPU hardware, ultra-low latency)"]
+        Fireworks["Fireworks AI<br/>(serverless, fine-tuned models)"]
+        LlamaAPI["Llama API<br/>(first-party, llama.com)"]
     end
 
     Local -->|"inference request"| App["Your Application"]

--- a/next/content/docs/en/model-providers/mistral.mdx
+++ b/next/content/docs/en/model-providers/mistral.mdx
@@ -49,21 +49,21 @@ La Plateforme provides a text embedding endpoint (`/v1/embeddings`) backed by Mi
 
 ```mermaid
 flowchart LR
-    Dev["Developer / Application"] -->|"Bearer token"| API["La Plateforme\napi.mistral.ai (EU hosted)"]
+    Dev["Developer / Application"] -->|"Bearer token"| API["La Plateforme<br/>api.mistral.ai (EU hosted)"]
 
-    API -->|"routes to model"| Large["Mistral Large 3\nopen-weight MoE flagship"]
-    API -->|"routes to model"| Medium["Mistral Medium 3.5\ndense, 128B"]
-    API -->|"routes to model"| Devstral["Devstral 2\ncode generation, 123B"]
-    API -->|"routes to model"| Small["Mistral Small 4\ncost-efficient"]
-    API -->|"embedding endpoint"| Embed["Mistral Embed\n1024-dim multilingual vectors"]
+    API -->|"routes to model"| Large["Mistral Large 3<br/>open-weight MoE flagship"]
+    API -->|"routes to model"| Medium["Mistral Medium 3.5<br/>dense, 128B"]
+    API -->|"routes to model"| Devstral["Devstral 2<br/>code generation, 123B"]
+    API -->|"routes to model"| Small["Mistral Small 4<br/>cost-efficient"]
+    API -->|"embedding endpoint"| Embed["Mistral Embed<br/>1024-dim multilingual vectors"]
 
-    HF["Hugging Face Hub\nopen weights"] -->|"download weights"| SelfHost
+    HF["Hugging Face Hub<br/>open weights"] -->|"download weights"| SelfHost
 
     subgraph SelfHost["Self-hosted inference"]
         direction LR
-        vLLM["vLLM\n(OpenAI-compatible server)"]
-        TF["Transformers\n(research / fine-tuning)"]
-        LCPP["llama.cpp\n(CPU / consumer GPU, GGUF)"]
+        vLLM["vLLM<br/>(OpenAI-compatible server)"]
+        TF["Transformers<br/>(research / fine-tuning)"]
+        LCPP["llama.cpp<br/>(CPU / consumer GPU, GGUF)"]
     end
 
     SelfHost -->|"inference response"| App["Your Application"]

--- a/next/content/docs/en/model-providers/openai.mdx
+++ b/next/content/docs/en/model-providers/openai.mdx
@@ -30,7 +30,7 @@ GPT-5.4 and GPT-5.5 support five reasoning modes — `none`, `low`, `medium`, `h
 ```mermaid
 flowchart LR
   Client[Client app] -->|POST messages array| ChatAPI[/v1/chat/completions]
-  ChatAPI -->|model routing| Selector{Model\nselector}
+  ChatAPI -->|model routing| Selector{Model<br/>selector}
   Selector -->|flagship| GPT55[GPT-5.5]
   Selector -->|balanced| GPT54[GPT-5.4]
   Selector -->|cost-optimized| Mini[GPT-5.4 mini]
@@ -50,7 +50,7 @@ GPT-5.4 and GPT-5.5 also support built-in tools: web search, file search, code i
 flowchart LR
   User[User query] --> LLM[GPT-5.4]
   LLM -->|decides to call tool| ToolCall[tool_calls JSON]
-  ToolCall -->|your code executes| ExtFn[External function\nor API]
+  ToolCall -->|your code executes| ExtFn[External function<br/>or API]
   ExtFn -->|result as tool message| LLM
   LLM -->|final answer| User
 ```

--- a/next/content/docs/en/model-routing/index.mdx
+++ b/next/content/docs/en/model-routing/index.mdx
@@ -18,12 +18,12 @@ Routing is distinct from cascading (which always starts at the cheapest tier and
 
 ```mermaid
 flowchart LR
-  Request[Query] --> SemCache{Semantic cache\nhit?}
-  SemCache -->|Yes| CacheHit[Cached response\n0 model cost]
+  Request[Query] --> SemCache{Semantic cache<br/>hit?}
+  SemCache -->|Yes| CacheHit[Cached response<br/>0 model cost]
   SemCache -->|No| Router[Model router]
-  Router -->|simple| SmallModel[Small model\ne.g. Gemini Flash / Haiku]
-  Router -->|medium| MidModel[Mid model\ne.g. GPT-4o / Sonnet]
-  Router -->|complex| LargeModel[Large model\ne.g. o3 / Opus]
+  Router -->|simple| SmallModel[Small model<br/>e.g. Gemini Flash / Haiku]
+  Router -->|medium| MidModel[Mid model<br/>e.g. GPT-4o / Sonnet]
+  Router -->|complex| LargeModel[Large model<br/>e.g. o3 / Opus]
   SmallModel --> Cache[Store in semantic cache]
   MidModel --> Cache
   LargeModel --> Cache

--- a/next/content/docs/en/observability/cost-attribution.mdx
+++ b/next/content/docs/en/observability/cost-attribution.mdx
@@ -26,11 +26,11 @@ These attributes, combined with custom dimension tags (user ID, feature name, ex
 
 ```mermaid
 flowchart LR
-  Request[User request] -->|tagged with user_id + feature| Span[OTel span\ngen_ai.usage.input_tokens\ngen_ai.usage.output_tokens]
+  Request[User request] -->|tagged with user_id + feature| Span[OTel span<br/>gen_ai.usage.input_tokens<br/>gen_ai.usage.output_tokens]
   Span -->|export| Backend[Observability backend]
   Backend -->|token × price lookup| CostEngine[Cost calculation]
-  CostEngine --> Dashboard[Cost dashboard\nby user · team · model · feature]
-  Dashboard --> Alerts[Budget alerts\n$ / day threshold]
+  CostEngine --> Dashboard[Cost dashboard<br/>by user · team · model · feature]
+  Dashboard --> Alerts[Budget alerts<br/>$ / day threshold]
 ```
 
 At instrumentation time, custom span attributes tag each LLM call with business dimensions (`user.id`, `team.name`, `feature.name`, `experiment.id`). The observability backend multiplies token counts by the provider's per-token price table (updated periodically) to compute dollar cost. Aggregated dashboards and alerts fire when per-user or per-feature spend exceeds configured thresholds.

--- a/next/content/docs/en/observability/index.mdx
+++ b/next/content/docs/en/observability/index.mdx
@@ -24,8 +24,8 @@ flowchart TD
   App -->|LLM call| LLMProvider[LLM provider API]
   App -->|tool call| Tool[External tool]
   App -->|vector query| VectorDB[Vector store]
-  Collector -->|OTLP| Backend[Observability backend\nLangfuse / Datadog / Grafana]
-  Backend --> Dashboard[Dashboards\nTraces · Cost · Latency · Quality]
+  Collector -->|OTLP| Backend[Observability backend<br/>Langfuse / Datadog / Grafana]
+  Backend --> Dashboard[Dashboards<br/>Traces · Cost · Latency · Quality]
 ```
 
 Each logical operation — an LLM call, a retrieval step, a tool invocation — is wrapped in an **OTel span**. Spans carry start/end timestamps, status, and attributes. Nested spans form a **trace tree** that represents the full execution path of a single request. Backends ingest traces over OTLP (HTTP or gRPC) and render them as waterfall diagrams, enabling root-cause analysis when a response is slow or incorrect.

--- a/next/content/docs/en/observability/langfuse.mdx
+++ b/next/content/docs/en/observability/langfuse.mdx
@@ -26,7 +26,7 @@ Key capabilities:
 flowchart LR
   App[LLM application] -->|SDK or OTLP| Langfuse[Langfuse server]
   Langfuse -->|store| DB[(PostgreSQL + ClickHouse)]
-  DB --> UI[Web dashboard\nTraces · Prompts · Scores]
+  DB --> UI[Web dashboard<br/>Traces · Prompts · Scores]
   UI --> Annotators[Human annotators]
   UI --> Evals[Automated eval jobs]
   Langfuse -->|export| Analytics[Cost / quality reports]

--- a/next/content/docs/en/observability/tracing.mdx
+++ b/next/content/docs/en/observability/tracing.mdx
@@ -32,10 +32,10 @@ Each OTel span has:
 
 ```mermaid
 flowchart TD
-  UserSpan[Span: handle_user_request\ntrace_id=abc123] -->|child| RetSpan[Span: vector_search\nlatency=42ms, results=4]
-  UserSpan -->|child| LLMSpan[Span: gen_ai.chat\nmodel=gpt-4o, tokens=1240]
-  LLMSpan -->|child| ToolSpan[Span: tool_call::get_weather\nlatency=210ms]
-  UserSpan -->|child| GuardSpan[Span: guardrail_check\nresult=pass]
+  UserSpan[Span: handle_user_request<br/>trace_id=abc123] -->|child| RetSpan[Span: vector_search<br/>latency=42ms, results=4]
+  UserSpan -->|child| LLMSpan[Span: gen_ai.chat<br/>model=gpt-4o, tokens=1240]
+  LLMSpan -->|child| ToolSpan[Span: tool_call::get_weather<br/>latency=210ms]
+  UserSpan -->|child| GuardSpan[Span: guardrail_check<br/>result=pass]
 ```
 
 The OTel SDK, instrumentation libraries (opentelemetry-instrumentation-openai, opentelemetry-instrumentation-langchain), or manual span creation propagate the `trace_id` through all nested calls. The OTel Collector receives spans, applies sampling and batching, and forwards them over OTLP to an observability backend.

--- a/next/content/docs/en/prompt-engineering/automatic-prompt-engineering.mdx
+++ b/next/content/docs/en/prompt-engineering/automatic-prompt-engineering.mdx
@@ -21,14 +21,14 @@ APE is distinct from soft prompt tuning (which optimizes continuous token embedd
 
 ```mermaid
 flowchart TD
-    Demos["Demonstration examples\n(input → output pairs)"] -->|"describe task"| MetaLLM["Meta-LLM\n(instruction proposer)"]
-    MetaLLM -->|"generate N candidate instructions"| Pool["Candidate instruction pool\n[instr_1, instr_2, ..., instr_N]"]
-    Pool -->|"each instruction tested"| Eval["Evaluation on\nheld-out benchmark"]
-    Eval -->|"score each candidate"| Scores["Scored instructions\n[(instr_1, 0.72), (instr_2, 0.85), ...]"]
+    Demos["Demonstration examples<br/>(input → output pairs)"] -->|"describe task"| MetaLLM["Meta-LLM<br/>(instruction proposer)"]
+    MetaLLM -->|"generate N candidate instructions"| Pool["Candidate instruction pool<br/>[instr_1, instr_2, ..., instr_N]"]
+    Pool -->|"each instruction tested"| Eval["Evaluation on<br/>held-out benchmark"]
+    Eval -->|"score each candidate"| Scores["Scored instructions<br/>[(instr_1, 0.72), (instr_2, 0.85), ...]"]
     Scores -->|"select top-K"| Select["Top-K instructions"]
-    Select -->|"resample variants"| Refine["Iterative refinement\n(paraphrase / edit)"]
+    Select -->|"resample variants"| Refine["Iterative refinement<br/>(paraphrase / edit)"]
     Refine -->|"new candidates"| Eval
-    Scores -->|"best instruction"| Output["Optimal instruction\n→ deployed prompt"]
+    Scores -->|"best instruction"| Output["Optimal instruction<br/>→ deployed prompt"]
 ```
 
 ### Candidate generation

--- a/next/content/docs/en/prompt-engineering/debiasing-techniques.mdx
+++ b/next/content/docs/en/prompt-engineering/debiasing-techniques.mdx
@@ -21,16 +21,16 @@ Debiasing at the prompt level is one of several available interventions. Alterna
 
 ```mermaid
 flowchart TD
-    Input["User input\n(query / task)"] -->|"analyze for bias triggers"| BiasCheck{"Bias risk\nassessment"}
-    BiasCheck -->|"social/demographic context"| CounterFact["Counterfactual\nbalancing"]
-    BiasCheck -->|"evaluation / judging task"| PosDebias["Positional & verbosity\ndebiasing"]
-    BiasCheck -->|"opinion / advice request"| SycophDebias["Sycophancy\nmitigation"]
-    BiasCheck -->|"all tasks"| NeutralInstruct["Neutral instruction\ninjection"]
-    CounterFact -->|"multiple perspectives generated"| Aggregator["Response\naggregation"]
+    Input["User input<br/>(query / task)"] -->|"analyze for bias triggers"| BiasCheck{"Bias risk<br/>assessment"}
+    BiasCheck -->|"social/demographic context"| CounterFact["Counterfactual<br/>balancing"]
+    BiasCheck -->|"evaluation / judging task"| PosDebias["Positional & verbosity<br/>debiasing"]
+    BiasCheck -->|"opinion / advice request"| SycophDebias["Sycophancy<br/>mitigation"]
+    BiasCheck -->|"all tasks"| NeutralInstruct["Neutral instruction<br/>injection"]
+    CounterFact -->|"multiple perspectives generated"| Aggregator["Response<br/>aggregation"]
     PosDebias -->|"randomized ordering + calibration"| Aggregator
     SycophDebias -->|"steelman + evidence-first"| Aggregator
     NeutralInstruct -->|"constrained generation"| Aggregator
-    Aggregator -->|"bias-reduced output"| EvalLoop{"Bias\nevaluation"}
+    Aggregator -->|"bias-reduced output"| EvalLoop{"Bias<br/>evaluation"}
     EvalLoop -->|"passes threshold"| Output["Final response"]
     EvalLoop -->|"bias detected"| Input
 ```

--- a/next/content/docs/en/prompt-engineering/max-tokens-stop-sequences.mdx
+++ b/next/content/docs/en/prompt-engineering/max-tokens-stop-sequences.mdx
@@ -20,13 +20,13 @@ Max tokens, stop sequences, and repetition penalties are generation-control para
 ```mermaid
 flowchart TD
   START([Start generation]) --> LOOP[Generate next token]
-  LOOP --> EOS{End-of-sequence\ntoken?}
+  LOOP --> EOS{End-of-sequence<br/>token?}
   EOS -->|yes| DONE([Return output])
-  EOS -->|no| MAXT{Tokens generated\n≥ max_tokens?}
+  EOS -->|no| MAXT{Tokens generated<br/>≥ max_tokens?}
   MAXT -->|yes| DONE
-  MAXT -->|no| STOP{Output ends with\na stop sequence?}
+  MAXT -->|no| STOP{Output ends with<br/>a stop sequence?}
   STOP -->|yes| DONE
-  STOP -->|no| REP[Apply repetition\npenalty to logits]
+  STOP -->|no| REP[Apply repetition<br/>penalty to logits]
   REP --> LOOP
 ```
 

--- a/next/content/docs/en/prompt-engineering/prompt-ensembling.mdx
+++ b/next/content/docs/en/prompt-engineering/prompt-ensembling.mdx
@@ -28,7 +28,7 @@ flowchart TD
   P2 -->|"LLM call → output"| O2[Output 2]
   P3 -->|"LLM call → output"| O3[Output 3]
   PK -->|"LLM call → output"| OK[Output K]
-  O1 -->|"extract answer"| Agg{Aggregation\nstrategy}
+  O1 -->|"extract answer"| Agg{Aggregation<br/>strategy}
   O2 -->|"extract answer"| Agg
   O3 -->|"extract answer"| Agg
   OK -->|"extract answer"| Agg

--- a/next/content/docs/en/prompt-engineering/prompt-formats.mdx
+++ b/next/content/docs/en/prompt-engineering/prompt-formats.mdx
@@ -87,10 +87,10 @@ flowchart TD
   Raw[Raw request] --> Role{Durable rule or task?}
   Role -->|durable| Sys[system / developer / system_instruction]
   Role -->|task + data| User[user message]
-  User --> Delim[Wrap data in delimiter\nXML tags / fenced block]
+  User --> Delim[Wrap data in delimiter<br/>XML tags / fenced block]
   Sys --> Model[LLM]
   Delim --> Model
-  Model --> Out[Output contract\nschema / tags / prefill]
+  Model --> Out[Output contract<br/>schema / tags / prefill]
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/prompt-engineering/self-consistency.mdx
+++ b/next/content/docs/en/prompt-engineering/self-consistency.mdx
@@ -20,11 +20,11 @@ What makes self-consistency practically useful — and distinct from simply addi
 
 ```mermaid
 flowchart TD
-  Prompt[Question + CoT prompt] -->|"sample, temp > 0"| Path1[Reasoning path 1\n-> Answer A]
-  Prompt -->|"sample, temp > 0"| Path2[Reasoning path 2\n-> Answer A]
-  Prompt -->|"sample, temp > 0"| Path3[Reasoning path 3\n-> Answer B]
-  Prompt -->|"sample, temp > 0"| PathN[Reasoning path N\n-> Answer A]
-  Path1 -->|"extract answer"| Vote{Majority\nvote}
+  Prompt[Question + CoT prompt] -->|"sample, temp > 0"| Path1[Reasoning path 1<br/>-> Answer A]
+  Prompt -->|"sample, temp > 0"| Path2[Reasoning path 2<br/>-> Answer A]
+  Prompt -->|"sample, temp > 0"| Path3[Reasoning path 3<br/>-> Answer B]
+  Prompt -->|"sample, temp > 0"| PathN[Reasoning path N<br/>-> Answer A]
+  Path1 -->|"extract answer"| Vote{Majority<br/>vote}
   Path2 -->|"extract answer"| Vote
   Path3 -->|"extract answer"| Vote
   PathN -->|"extract answer"| Vote

--- a/next/content/docs/en/prompt-engineering/self-evaluation-calibration.mdx
+++ b/next/content/docs/en/prompt-engineering/self-evaluation-calibration.mdx
@@ -21,9 +21,9 @@ Together, self-evaluation and calibration address two distinct but related failu
 ```mermaid
 flowchart TD
   Input[User question / task] -->|"generation prompt"| Draft[Initial response draft]
-  Draft -->|"self-critique prompt"| Critique[Critique: identify\nerrors and gaps]
-  Critique -->|"confidence scoring prompt"| Score[Confidence score\n+ reasoning]
-  Score -->|"score < threshold"| CoV[Chain-of-verification:\nfact-check sub-claims]
+  Draft -->|"self-critique prompt"| Critique[Critique: identify<br/>errors and gaps]
+  Critique -->|"confidence scoring prompt"| Score[Confidence score<br/>+ reasoning]
+  Score -->|"score < threshold"| CoV[Chain-of-verification:<br/>fact-check sub-claims]
   Score -->|"score >= threshold"| Accept[Accept response]
   CoV -->|"failed verifications"| Revise[Revised response]
   Revise -->|"re-score"| Score

--- a/next/content/docs/en/prompt-engineering/step-back-prompting.mdx
+++ b/next/content/docs/en/prompt-engineering/step-back-prompting.mdx
@@ -21,8 +21,8 @@ In the original paper, step-back prompting is demonstrated with few-shot example
 ```mermaid
 flowchart TD
   Original[Original specific question] -->|"step-back prompt"| Abstract[Abstract / higher-level question]
-  Abstract -->|"answer abstract question"| Principle[General principle\nor concept]
-  Original -->|"combine with principle"| Grounded[Grounded prompt:\nprinciple + original question]
+  Abstract -->|"answer abstract question"| Principle[General principle<br/>or concept]
+  Original -->|"combine with principle"| Grounded[Grounded prompt:<br/>principle + original question]
   Principle -->|"provides context"| Grounded
   Grounded -->|"reason to answer"| Final[Final answer]
 ```

--- a/next/content/docs/en/prompt-engineering/structured-outputs.mdx
+++ b/next/content/docs/en/prompt-engineering/structured-outputs.mdx
@@ -21,9 +21,9 @@ Understanding which technique to apply — and why — matters for anyone buildi
 ```mermaid
 flowchart LR
   Prompt[Prompt + schema] -->|"structured request"| LLM[LLM]
-  LLM -->|"raw structured response"| Validation{Schema\nvalidation}
-  Validation -->|"valid"| Downstream[Downstream system\nor application]
-  Validation -->|"invalid"| Retry[Retry / correction\nloop]
+  LLM -->|"raw structured response"| Validation{Schema<br/>validation}
+  Validation -->|"valid"| Downstream[Downstream system<br/>or application]
+  Validation -->|"invalid"| Retry[Retry / correction<br/>loop]
   Retry -->|"reprompt with error"| LLM
 ```
 

--- a/next/content/docs/en/prompt-engineering/system-role-contextual-prompting.mdx
+++ b/next/content/docs/en/prompt-engineering/system-role-contextual-prompting.mdx
@@ -20,10 +20,10 @@ A **system prompt** (also called a system message) is a special input slot in mo
 
 ```mermaid
 flowchart TD
-    System["System message\n(role + instructions + constraints)"] -->|"prepended to context"| Context
-    Context["Contextual information\n(documents, history, data)"] -->|"injected before user turn"| UserMsg
-    UserMsg["User message\n(query / task)"] -->|"full prompt assembled"| LLM["LLM"]
-    LLM -->|"constrained by system message"| Response["Assistant response\n(persona-consistent, grounded)"]
+    System["System message<br/>(role + instructions + constraints)"] -->|"prepended to context"| Context
+    Context["Contextual information<br/>(documents, history, data)"] -->|"injected before user turn"| UserMsg
+    UserMsg["User message<br/>(query / task)"] -->|"full prompt assembled"| LLM["LLM"]
+    LLM -->|"constrained by system message"| Response["Assistant response<br/>(persona-consistent, grounded)"]
     Response -->|"conversation continues"| UserMsg
 ```
 

--- a/next/content/docs/en/prompt-security/guardrails.mdx
+++ b/next/content/docs/en/prompt-security/guardrails.mdx
@@ -22,14 +22,14 @@ A complete guardrail architecture enforces four categories of control:
 
 ```mermaid
 flowchart TD
-  Input[User input] --> PIIScan[PII scanner\ndetect names, emails, phone, etc.]
-  PIIScan -->|anonymise| InjectionDetect[Injection detector\nclassifier / pattern match]
-  InjectionDetect -->|safe| TopicGate[Topic / policy gate\nallowed topic list]
+  Input[User input] --> PIIScan[PII scanner<br/>detect names, emails, phone, etc.]
+  PIIScan -->|anonymise| InjectionDetect[Injection detector<br/>classifier / pattern match]
+  InjectionDetect -->|safe| TopicGate[Topic / policy gate<br/>allowed topic list]
   InjectionDetect -->|blocked| RejectIn[Reject input]
   TopicGate -->|allowed| LLM[LLM generation]
   TopicGate -->|off-topic| Deflect[Deflect response]
   LLM --> ToxScan[Toxicity / harm classifier]
-  ToxScan -->|safe| PIIOut[Output PII scanner\nredact before send]
+  ToxScan -->|safe| PIIOut[Output PII scanner<br/>redact before send]
   ToxScan -->|unsafe| Fallback[Fallback / safe response]
   PIIOut --> User[Response to user]
 ```

--- a/next/content/docs/en/prompt-security/index.mdx
+++ b/next/content/docs/en/prompt-security/index.mdx
@@ -25,10 +25,10 @@ This section covers:
 
 ```mermaid
 flowchart LR
-  UserInput[User input] --> InputGuard[Input guardrail\ninjection detect / PII scan / topic gate]
+  UserInput[User input] --> InputGuard[Input guardrail<br/>injection detect / PII scan / topic gate]
   InputGuard -->|safe| LLM[LLM]
   InputGuard -->|blocked| Reject[Rejection response]
-  LLM --> OutputGuard[Output guardrail\ntoxicity / PII / hallucination / policy]
+  LLM --> OutputGuard[Output guardrail<br/>toxicity / PII / hallucination / policy]
   OutputGuard -->|safe| Response[Response to user]
   OutputGuard -->|blocked| Fallback[Fallback / redacted response]
 ```

--- a/next/content/docs/en/prompt-security/prompt-injection.mdx
+++ b/next/content/docs/en/prompt-security/prompt-injection.mdx
@@ -18,16 +18,16 @@ Unlike SQL injection or buffer overflows, prompt injection exploits a fundamenta
 
 ```mermaid
 flowchart TD
-  Attacker[Attacker] -->|embeds malicious text| Vector[Injection vector\ne.g. document / user input / tool result]
-  Vector --> Prompt[Combined prompt\nsystem + retrieval + user]
+  Attacker[Attacker] -->|embeds malicious text| Vector[Injection vector<br/>e.g. document / user input / tool result]
+  Vector --> Prompt[Combined prompt<br/>system + retrieval + user]
   Prompt --> LLM[LLM processes tokens]
-  LLM -->|injection succeeds| Hijack[Override intent\nexfiltrate data / bypass policy]
+  LLM -->|injection succeeds| Hijack[Override intent<br/>exfiltrate data / bypass policy]
   LLM -->|injection blocked| Safe[Normal response]
 
-  Defense[Defenses] --> InputClassifier[Input classifier\ndetect injection patterns]
-  Defense --> Boundary[Boundary markers\nXML tags / delimiters]
-  Defense --> PrivilegeCtrl[Privilege separation\nuntrusted content zone]
-  Defense --> ToolGuard[Tool-call allowlist\n sandboxed execution]
+  Defense[Defenses] --> InputClassifier[Input classifier<br/>detect injection patterns]
+  Defense --> Boundary[Boundary markers<br/>XML tags / delimiters]
+  Defense --> PrivilegeCtrl[Privilege separation<br/>untrusted content zone]
+  Defense --> ToolGuard[Tool-call allowlist<br/> sandboxed execution]
 ```
 
 ## Attack taxonomy

--- a/next/content/docs/en/pruning/index.mdx
+++ b/next/content/docs/en/pruning/index.mdx
@@ -19,7 +19,7 @@ Pruning is most effective when combined with other [model compression](/docs/mod
 
 ```mermaid
 flowchart LR
-  Trained["Fully trained model"] -->|"measure importance"| Score["Importance scoring\n(magnitude / gradient / L1)"]
+  Trained["Fully trained model"] -->|"measure importance"| Score["Importance scoring<br/>(magnitude / gradient / L1)"]
   Score -->|"rank parameters"| Rank["Rank weights or channels"]
   Rank -->|"remove bottom N%"| Prune["Prune (zero out or remove)"]
   Prune -->|"recover accuracy"| FineTune["Fine-tune on training data"]
@@ -32,8 +32,8 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  Model["Weight matrix W\n(dense, all connections)"] -->|"unstructured: zero individual weights"| Sparse["Sparse W\n(same shape, many zeros)"]
-  Model -->|"structured: remove channel / head"| Dense["Smaller dense W\n(fewer rows or columns)"]
+  Model["Weight matrix W<br/>(dense, all connections)"] -->|"unstructured: zero individual weights"| Sparse["Sparse W<br/>(same shape, many zeros)"]
+  Model -->|"structured: remove channel / head"| Dense["Smaller dense W<br/>(fewer rows or columns)"]
   Sparse -->|"requires sparse kernels"| SpeedupSparse["Memory savings, limited speedup"]
   Dense -->|"standard matmul"| SpeedupDense["Real wall-clock speedup"]
 ```

--- a/next/content/docs/en/quantization/index.mdx
+++ b/next/content/docs/en/quantization/index.mdx
@@ -19,17 +19,17 @@ Quantization exists on a spectrum of approaches: **post-training quantization (P
 
 ```mermaid
 flowchart LR
-  FP32["FP32 / BF16 weights"] -->|"run calibration data"| Calibrate["Collect activation stats\n(min, max, percentiles)"]
+  FP32["FP32 / BF16 weights"] -->|"run calibration data"| Calibrate["Collect activation stats<br/>(min, max, percentiles)"]
   Calibrate -->|"compute"| Scale["Scale + zero-point per layer"]
   Scale -->|"map weights"| INT8["INT8 / INT4 weights"]
-  INT8 -->|"deploy"| Runtime["Inference runtime\n(GPU tensor cores / NPU)"]
+  INT8 -->|"deploy"| Runtime["Inference runtime<br/>(GPU tensor cores / NPU)"]
 ```
 
 ### Quantization-aware training (QAT)
 
 ```mermaid
 flowchart LR
-  Model["FP32 model"] -->|"insert"| FakeQuant["Fake quantization nodes\n(simulate rounding in forward pass)"]
+  Model["FP32 model"] -->|"insert"| FakeQuant["Fake quantization nodes<br/>(simulate rounding in forward pass)"]
   FakeQuant -->|"fine-tune with data"| Adapted["Weights adapted to quantization"]
   Adapted -->|"strip fake quant"| INT8Model["INT8 model"]
   INT8Model -->|"deploy"| Runtime["Inference runtime"]

--- a/next/content/docs/en/rag/agentic-rag.mdx
+++ b/next/content/docs/en/rag/agentic-rag.mdx
@@ -28,14 +28,14 @@ Research benchmarks consistently show that agentic RAG outperforms static pipeli
 
 ```mermaid
 flowchart TD
-  Q[User question] --> Plan[Agent: decompose into sub-questions\nand plan retrieval strategy]
-  Plan --> Retrieve[Retrieve evidence\nfrom one or more tools]
-  Retrieve --> Grade[Agent: grade retrieved docs\nfor relevance and quality]
+  Q[User question] --> Plan[Agent: decompose into sub-questions<br/>and plan retrieval strategy]
+  Plan --> Retrieve[Retrieve evidence<br/>from one or more tools]
+  Retrieve --> Grade[Agent: grade retrieved docs<br/>for relevance and quality]
   Grade --> Sufficient{Evidence sufficient?}
-  Sufficient -->|No| Rewrite[Rewrite query\nor choose different tool]
+  Sufficient -->|No| Rewrite[Rewrite query<br/>or choose different tool]
   Rewrite --> Retrieve
   Sufficient -->|Yes| Compose[Compose answer from evidence]
-  Compose --> Reflect[Agent: self-critique answer\nfor completeness and accuracy]
+  Compose --> Reflect[Agent: self-critique answer<br/>for completeness and accuracy]
   Reflect --> Done{Satisfactory?}
   Done -->|No — revise| Retrieve
   Done -->|Yes| Answer[Final answer + citations]

--- a/next/content/docs/en/rag/graphrag.mdx
+++ b/next/content/docs/en/rag/graphrag.mdx
@@ -30,11 +30,11 @@ The offline indexing phase is GraphRAG's most distinctive step and its primary c
 ```mermaid
 flowchart TD
   Docs[Raw documents] --> Chunk[Text chunking]
-  Chunk --> Extract[LLM entity & relationship extraction\nper chunk]
-  Extract --> Graph[Knowledge graph\nentities + relationships + claims]
-  Graph --> Community[Community detection\nLeiden algorithm]
-  Community --> Summarize[LLM community summary generation\nper community level]
-  Summarize --> Index[Graph index + vector embeddings\nstored in parquet / vector DB]
+  Chunk --> Extract[LLM entity & relationship extraction<br/>per chunk]
+  Extract --> Graph[Knowledge graph<br/>entities + relationships + claims]
+  Graph --> Community[Community detection<br/>Leiden algorithm]
+  Community --> Summarize[LLM community summary generation<br/>per community level]
+  Summarize --> Index[Graph index + vector embeddings<br/>stored in parquet / vector DB]
 ```
 
 1. **Chunking** — Documents are split into text units (default ~300 tokens with overlap).
@@ -49,8 +49,8 @@ flowchart TD
 ```mermaid
 flowchart LR
   Q[User query] --> Route{Query type}
-  Route -->|Global: themes / overview| GS[Global search\nmap-reduce over community summaries]
-  Route -->|Local: specific entity| LS[Local search\ngraph traversal from entity nodes]
+  Route -->|Global: themes / overview| GS[Global search<br/>map-reduce over community summaries]
+  Route -->|Local: specific entity| LS[Local search<br/>graph traversal from entity nodes]
   GS --> LLM[LLM synthesizes answer]
   LS --> LLM
   LLM --> Answer[Response with citations]

--- a/next/content/docs/en/rag/index.mdx
+++ b/next/content/docs/en/rag/index.mdx
@@ -25,7 +25,7 @@ flowchart LR
   CH -->|encode| EM[Embedding Model]
   EM -->|store| VDB[(Vector Database)]
 
-  CH -.->|strategy: fixed-size,\nsemantic, recursive| CH
+  CH -.->|strategy: fixed-size,<br/>semantic, recursive| CH
 ```
 
 ### Retrieval (query-time)

--- a/next/content/docs/en/structured-generation/constrained-decoding.mdx
+++ b/next/content/docs/en/structured-generation/constrained-decoding.mdx
@@ -22,7 +22,7 @@ Two classes of automata are used:
 
 ```mermaid
 flowchart LR
-  Schema[JSON Schema] -->|compile once| Automaton[Grammar automaton\nFSM or pushdown]
+  Schema[JSON Schema] -->|compile once| Automaton[Grammar automaton<br/>FSM or pushdown]
   Prompt[Prompt + partial output] -->|current parse state| Automaton
   Automaton -->|valid next token set| Mask[Token mask]
   Logits[Raw logits from LLM] -->|apply mask -inf| Masked[Masked logits]

--- a/next/content/docs/en/structured-generation/instructor-and-json-mode.mdx
+++ b/next/content/docs/en/structured-generation/instructor-and-json-mode.mdx
@@ -23,7 +23,7 @@ The practical choice:
 
 ```mermaid
 flowchart LR
-  PydanticModel[Pydantic model\ndefinition] -->|patch| InstructorClient[Instructor-patched client]
+  PydanticModel[Pydantic model<br/>definition] -->|patch| InstructorClient[Instructor-patched client]
   UserPrompt[User prompt] --> InstructorClient
   InstructorClient -->|tool call or JSON prompt| LLMProvider[LLM provider API]
   LLMProvider -->|raw JSON string| InstructorClient

--- a/next/content/docs/en/synthetic-data/generation-methods.mdx
+++ b/next/content/docs/en/synthetic-data/generation-methods.mdx
@@ -21,16 +21,16 @@ The field can be organised into four families:
 
 ```mermaid
 flowchart TD
-  Seed[Seed tasks\n~175 human examples] --> SelfInstr[Self-Instruct\nmodel generates new tasks]
+  Seed[Seed tasks<br/>~175 human examples] --> SelfInstr[Self-Instruct<br/>model generates new tasks]
   SelfInstr -->|filter| SIData[Self-instruct dataset]
 
-  Teacher[Teacher model\nGPT-4o / Claude Opus] --> Distil[Distillation\nteacher annotates inputs]
+  Teacher[Teacher model<br/>GPT-4o / Claude Opus] --> Distil[Distillation<br/>teacher annotates inputs]
   Distil -->|teacher responses| DistilData[Distillation dataset]
 
-  Base[Base instructions] --> Evol[Evol-Instruct\nrewrite to add complexity]
+  Base[Base instructions] --> Evol[Evol-Instruct<br/>rewrite to add complexity]
   Evol -->|harder variants| EvolData[Evolved dataset]
 
-  Personas[Persona library\n1M+ personas] --> Magpie[Magpie / persona sampling\nmulti-turn user simulation]
+  Personas[Persona library<br/>1M+ personas] --> Magpie[Magpie / persona sampling<br/>multi-turn user simulation]
   Magpie -->|multi-turn pairs| PersonaData[Persona dataset]
 
   SIData --> Combine[Combine + deduplicate]

--- a/next/content/docs/en/synthetic-data/index.mdx
+++ b/next/content/docs/en/synthetic-data/index.mdx
@@ -26,10 +26,10 @@ This section covers:
 
 ```mermaid
 flowchart LR
-  Seeds[Seed tasks / prompts\nfew real examples] --> Generator[Generator model\nGPT-4o / Claude / Llama]
-  Generator -->|raw synthetic pairs| Filter[Quality filter\nLLM judge + dedup]
+  Seeds[Seed tasks / prompts<br/>few real examples] --> Generator[Generator model<br/>GPT-4o / Claude / Llama]
+  Generator -->|raw synthetic pairs| Filter[Quality filter<br/>LLM judge + dedup]
   Filter -->|clean dataset| Train[Fine-tune student model]
-  Train -->|student outputs| Verify[Optional: verification\ncode execution, factcheck]
+  Train -->|student outputs| Verify[Optional: verification<br/>code execution, factcheck]
   Verify -->|pass| Dataset[Final training set]
   Verify -->|fail| Reject[Discard]
 ```

--- a/next/content/docs/en/synthetic-data/quality-filtering.mdx
+++ b/next/content/docs/en/synthetic-data/quality-filtering.mdx
@@ -18,15 +18,15 @@ Filtering operates at two stages: (1) immediately after context / instruction ge
 
 ```mermaid
 flowchart TD
-  RawData[Raw synthetic pairs\ninstruction + response] --> Dedup[Deduplication\nMinHash / ROUGE-L threshold]
-  Dedup --> LengthFilter[Length / format check\nmin/max tokens, JSON validity]
-  LengthFilter --> LLMJudge[LLM-as-a-judge\nrubric scoring 1-5]
-  LLMJudge -->|score ≥ threshold| RewardModel[Reward model score\noptional second gate]
+  RawData[Raw synthetic pairs<br/>instruction + response] --> Dedup[Deduplication<br/>MinHash / ROUGE-L threshold]
+  Dedup --> LengthFilter[Length / format check<br/>min/max tokens, JSON validity]
+  LengthFilter --> LLMJudge[LLM-as-a-judge<br/>rubric scoring 1-5]
+  LLMJudge -->|score ≥ threshold| RewardModel[Reward model score<br/>optional second gate]
   LLMJudge -->|score < threshold| Reject1[Discard]
-  RewardModel -->|pass| VerifTask{Verifiable task?\ncode / math}
+  RewardModel -->|pass| VerifTask{Verifiable task?<br/>code / math}
   RewardModel -->|fail| Reject2[Discard]
-  VerifTask -->|Yes| Execute[Execute / unit test\nor symbolic check]
-  VerifTask -->|No| Safety[Safety classifier\ntoxicity, PII, bias]
+  VerifTask -->|Yes| Execute[Execute / unit test<br/>or symbolic check]
+  VerifTask -->|No| Safety[Safety classifier<br/>toxicity, PII, bias]
   Execute -->|pass| Safety
   Execute -->|fail| Reject3[Discard]
   Safety -->|pass| FinalData[Final training set]

--- a/next/content/docs/en/tools/kiro.mdx
+++ b/next/content/docs/en/tools/kiro.mdx
@@ -32,7 +32,7 @@ flowchart LR
 
 ```mermaid
 flowchart LR
-  Event["IDE event\n(save / commit / test)"] -->|"triggers"| Hook["Agent hook"]
+  Event["IDE event<br/>(save / commit / test)"] -->|"triggers"| Hook["Agent hook"]
   Hook -->|"reads context"| Repo["Repo + steering files"]
   Hook -->|"runs task"| Agent["Agent"]
   Agent -->|"updates"| Outputs["Docs / tests / lint fixes"]

--- a/next/content/docs/en/tools/llamaindex.mdx
+++ b/next/content/docs/en/tools/llamaindex.mdx
@@ -19,10 +19,10 @@ LlamaIndex also supports [agents](/docs/agents): query engines can be registered
 
 ```mermaid
 flowchart LR
-  Source["Data source\n(files, APIs, DBs)"] -->|"load"| Loader["Document loader"]
-  Loader -->|"split"| Parser["Node parser\n(chunking)"]
+  Source["Data source<br/>(files, APIs, DBs)"] -->|"load"| Loader["Document loader"]
+  Loader -->|"split"| Parser["Node parser<br/>(chunking)"]
   Parser -->|"embed"| Embed["Embedding model"]
-  Embed -->|"store"| Index["Index\n(vector / keyword / graph)"]
+  Embed -->|"store"| Index["Index<br/>(vector / keyword / graph)"]
 ```
 
 ### Query pipeline
@@ -31,7 +31,7 @@ flowchart LR
 flowchart LR
   Query["User query"] -->|"embed & search"| Retriever["Retriever"]
   Retriever -->|"top-k nodes"| Reranker["Reranker (optional)"]
-  Reranker -->|"ranked context"| Synth["Response synthesizer\n(LLM)"]
+  Reranker -->|"ranked context"| Synth["Response synthesizer<br/>(LLM)"]
   Synth -->|"answer"| Response["Final response"]
 ```
 

--- a/next/content/docs/en/voice-agents/index.mdx
+++ b/next/content/docs/en/voice-agents/index.mdx
@@ -24,9 +24,9 @@ Key building blocks covered in this section:
 ```mermaid
 flowchart LR
   Mic[Microphone / phone audio] -->|WebRTC / SIP| VAD[VAD — speech segmentation]
-  VAD -->|speech segments| STT[ASR model\ne.g. Deepgram Nova-3]
-  STT -->|transcript| LLM[LLM\ne.g. GPT-4o / Claude]
-  LLM -->|text reply| TTS[TTS model\ne.g. ElevenLabs / Deepgram Aura]
+  VAD -->|speech segments| STT[ASR model<br/>e.g. Deepgram Nova-3]
+  STT -->|transcript| LLM[LLM<br/>e.g. GPT-4o / Claude]
+  LLM -->|text reply| TTS[TTS model<br/>e.g. ElevenLabs / Deepgram Aura]
   TTS -->|audio stream| Speaker[Speaker / telephony]
 ```
 

--- a/next/content/docs/en/voice-agents/realtime-audio.mdx
+++ b/next/content/docs/en/voice-agents/realtime-audio.mdx
@@ -15,8 +15,8 @@ tags:
 
 ```mermaid
 flowchart LR
-  Client[Browser / Phone] -->|WebRTC / SIP| Media[Media server\nLiveKit / Daily / Twilio]
-  Media -->|PCM audio| Agent[Agent process\nPython / Node]
+  Client[Browser / Phone] -->|WebRTC / SIP| Media[Media server<br/>LiveKit / Daily / Twilio]
+  Media -->|PCM audio| Agent[Agent process<br/>Python / Node]
   Agent -->|STT call| ASR[ASR API]
   Agent -->|LLM call| LLM[LLM API]
   Agent -->|TTS call| TTS[TTS API]

--- a/next/content/docs/en/voice-agents/stt-llm-tts-pipeline.mdx
+++ b/next/content/docs/en/voice-agents/stt-llm-tts-pipeline.mdx
@@ -18,13 +18,13 @@ The central constraint is a **300 ms budget**: at or below 300 ms total round-tr
 
 ```mermaid
 flowchart TD
-  Audio[Raw audio stream] --> VAD[Voice Activity Detection\nsilero-VAD / Deepgram streaming]
-  VAD -->|end-of-utterance signal| STT[ASR\nDeepgram Nova-3 / Whisper v3]
-  STT -->|transcript text| Prompt[Prompt construction\nsystem + history + user turn]
-  Prompt --> LLM[LLM — streaming\nGPT-4o / Claude / Gemini]
-  LLM -->|token stream| Splitter[Sentence splitter\nfirst 8-15 tokens → flush]
-  Splitter -->|sentence chunk| TTS[TTS synthesis\nElevenLabs / Deepgram Aura]
-  TTS -->|audio chunks| Playback[Audio playback\nWebRTC / PCM]
+  Audio[Raw audio stream] --> VAD[Voice Activity Detection<br/>silero-VAD / Deepgram streaming]
+  VAD -->|end-of-utterance signal| STT[ASR<br/>Deepgram Nova-3 / Whisper v3]
+  STT -->|transcript text| Prompt[Prompt construction<br/>system + history + user turn]
+  Prompt --> LLM[LLM — streaming<br/>GPT-4o / Claude / Gemini]
+  LLM -->|token stream| Splitter[Sentence splitter<br/>first 8-15 tokens → flush]
+  Splitter -->|sentence chunk| TTS[TTS synthesis<br/>ElevenLabs / Deepgram Aura]
+  TTS -->|audio chunks| Playback[Audio playback<br/>WebRTC / PCM]
 ```
 
 ### Stage 1 — Voice Activity Detection (VAD)

--- a/next/content/docs/pt-BR/agents/agent-runtimes.mdx
+++ b/next/content/docs/pt-BR/agents/agent-runtimes.mdx
@@ -30,9 +30,9 @@ O Paperclip (lançado em março de 2026) é um servidor Node.js + UI React que o
 
 ```mermaid
 flowchart TD
-  Need{What is the hard part?} -->|Build the agent app in JS| AK[AgentsKit\nfull-stack framework]
-  Need -->|One agent that persists\nand self-improves| HM[Hermes Agent\nself-hosted runtime]
-  Need -->|Coordinate many existing\nagents with oversight| PC[Paperclip\nUI orchestrator]
+  Need{What is the hard part?} -->|Build the agent app in JS| AK[AgentsKit<br/>full-stack framework]
+  Need -->|One agent that persists<br/>and self-improves| HM[Hermes Agent<br/>self-hosted runtime]
+  Need -->|Coordinate many existing<br/>agents with oversight| PC[Paperclip<br/>UI orchestrator]
   AK --> Prod[Production agent system]
   HM --> Prod
   PC --> Prod

--- a/next/content/docs/pt-BR/agents/anthropic-tool-use.mdx
+++ b/next/content/docs/pt-BR/agents/anthropic-tool-use.mdx
@@ -37,7 +37,7 @@ Tarefas complexas frequentemente requerem várias rodadas de chamadas de ferrame
 
 ```mermaid
 flowchart LR
-  User[User message] -->|appended to messages| API[Anthropic API\nClaude model]
+  User[User message] -->|appended to messages| API[Anthropic API<br/>Claude model]
   API -->|stop_reason: tool_use| Parse[Parse tool_use blocks]
   Parse -->|one block per tool call| Exec[Execute tools in parallel]
   Exec -->|results| Wrap[Wrap in tool_result blocks]

--- a/next/content/docs/pt-BR/agents/autogen.mdx
+++ b/next/content/docs/pt-BR/agents/autogen.mdx
@@ -39,7 +39,7 @@ flowchart LR
   Human[Human / Initiator] -->|initial message| UPA[UserProxyAgent]
   UPA -->|sends message| AA[AssistantAgent]
   AA -->|generates reply with code| UPA
-  UPA -->|executes code block| Exec[Code executor\nsubprocess / Docker]
+  UPA -->|executes code block| Exec[Code executor<br/>subprocess / Docker]
   Exec -->|stdout / stderr| UPA
   UPA -->|reports result| AA
   AA -->|revised reply or TERMINATE| UPA

--- a/next/content/docs/pt-BR/agents/conversational-memory.mdx
+++ b/next/content/docs/pt-BR/agents/conversational-memory.mdx
@@ -33,12 +33,12 @@ A memória de entidades extrai entidades nomeadas — pessoas, lugares, produtos
 
 ```mermaid
 flowchart TD
-  Msg[New User Message] -->|"add to"| Buffer[Buffer Memory\nlast N turns]
-  Msg -->|"embed query"| VectorDB[(Vector Memory\nembedding store)]
+  Msg[New User Message] -->|"add to"| Buffer[Buffer Memory<br/>last N turns]
+  Msg -->|"embed query"| VectorDB[(Vector Memory<br/>embedding store)]
   VectorDB -->|"retrieve similar turns"| Merge[Context Assembly]
   Buffer -->|"recent verbatim turns"| Merge
-  Summary[Summary Memory\nrunning narrative] -->|"inject summary"| Merge
-  Entities[Entity Memory\nkey facts / profiles] -->|"relevant entities"| Merge
+  Summary[Summary Memory<br/>running narrative] -->|"inject summary"| Merge
+  Entities[Entity Memory<br/>key facts / profiles] -->|"relevant entities"| Merge
   Merge -->|"assembled context"| LLM[LLM Inference]
   LLM -->|"response"| Out[Agent Output]
   LLM -->|"trigger summarize"| Summarizer[Summarizer LLM]

--- a/next/content/docs/pt-BR/agents/crewai.mdx
+++ b/next/content/docs/pt-BR/agents/crewai.mdx
@@ -37,11 +37,11 @@ O CrewAI vem com um decorador `@tool` compatível com ferramentas LangChain, tor
 ```mermaid
 flowchart TD
   Input[User goal / kickoff input] -->|starts| Crew[Crew orchestrator]
-  Crew -->|assigns task 1| Agent1[Researcher agent\nrole + goal + tools]
+  Crew -->|assigns task 1| Agent1[Researcher agent<br/>role + goal + tools]
   Agent1 -->|calls tools| Tools1[Web search / APIs]
   Tools1 -->|observation| Agent1
   Agent1 -->|task 1 output| Crew
-  Crew -->|injects context, assigns task 2| Agent2[Writer agent\nrole + goal + tools]
+  Crew -->|injects context, assigns task 2| Agent2[Writer agent<br/>role + goal + tools]
   Agent2 -->|calls tools| Tools2[File I/O / Code]
   Tools2 -->|observation| Agent2
   Agent2 -->|task 2 output| Crew

--- a/next/content/docs/pt-BR/agents/dag-agents.mdx
+++ b/next/content/docs/pt-BR/agents/dag-agents.mdx
@@ -35,11 +35,11 @@ No modo dinâmico, uma etapa de planejamento é executada primeiro e produz uma 
 
 ```mermaid
 flowchart LR
-  Start[User Goal] -->|"decompose goal"| TaskA[Task A\nResearch Topic 1]
-  Start -->|"decompose goal"| TaskB[Task B\nResearch Topic 2]
-  TaskA -->|"research result A"| TaskC[Task C\nSynthesize Results]
+  Start[User Goal] -->|"decompose goal"| TaskA[Task A<br/>Research Topic 1]
+  Start -->|"decompose goal"| TaskB[Task B<br/>Research Topic 2]
+  TaskA -->|"research result A"| TaskC[Task C<br/>Synthesize Results]
   TaskB -->|"research result B"| TaskC
-  TaskC -->|"synthesis"| TaskD[Task D\nWrite Final Report]
+  TaskC -->|"synthesis"| TaskD[Task D<br/>Write Final Report]
   TaskD -->|"report"| Output[Final Output]
 ```
 

--- a/next/content/docs/pt-BR/agents/langgraph.mdx
+++ b/next/content/docs/pt-BR/agents/langgraph.mdx
@@ -37,12 +37,12 @@ O LangGraph lida com ciclos nativamente: um nó pode ter uma aresta de volta par
 
 ```mermaid
 flowchart TD
-  Start([START]) -->|initializes state| CallModel[call_model node\nLLM generates response]
-  CallModel -->|reads tool_calls from state| Router{tools_router\nconditional edge}
-  Router -->|tool_calls present| ToolNode[tool_node\nexecutes tool calls]
+  Start([START]) -->|initializes state| CallModel[call_model node<br/>LLM generates response]
+  CallModel -->|reads tool_calls from state| Router{tools_router<br/>conditional edge}
+  Router -->|tool_calls present| ToolNode[tool_node<br/>executes tool calls]
   ToolNode -->|appends tool results to state| CallModel
-  Router -->|no tool_calls| End([END\nfinal answer])
-  CallModel -->|on error| ErrorHandler[error_handler node\nretry or escalate]
+  Router -->|no tool_calls| End([END<br/>final answer])
+  CallModel -->|on error| ErrorHandler[error_handler node<br/>retry or escalate]
   ErrorHandler -->|retry| CallModel
   ErrorHandler -->|max retries exceeded| End
 ```

--- a/next/content/docs/pt-BR/agents/memory.mdx
+++ b/next/content/docs/pt-BR/agents/memory.mdx
@@ -39,9 +39,9 @@ O ciclo de recuperação conecta todas as camadas. A cada turno, o agente consul
 
 ```mermaid
 flowchart LR
-  Input[User Input] -->|"new message"| WM[Working Memory\nContext Window]
+  Input[User Input] -->|"new message"| WM[Working Memory<br/>Context Window]
   WM -->|"query embedding"| Retrieval[Retrieval Engine]
-  Retrieval -->|"semantic search"| LTS[Long-term Store\nVector DB]
+  Retrieval -->|"semantic search"| LTS[Long-term Store<br/>Vector DB]
   LTS -->|"relevant chunks"| WM
   WM -->|"recent N turns"| STB[Short-term Buffer]
   STB -->|"inject history"| WM

--- a/next/content/docs/pt-BR/agents/self-critique.mdx
+++ b/next/content/docs/pt-BR/agents/self-critique.mdx
@@ -35,12 +35,12 @@ O Reflexion (Shinn et al., 2023) aplica reflexão no nível do episódio em vez 
 
 ```mermaid
 flowchart TD
-  Task[Input Task] -->|"initial prompt"| Generate[Generate\nInitial Output]
-  Generate -->|"draft output"| Evaluate[Evaluate\nCritic LLM]
-  Evaluate -->|"score + critique"| Decision{Score >=\nthreshold?}
+  Task[Input Task] -->|"initial prompt"| Generate[Generate<br/>Initial Output]
+  Generate -->|"draft output"| Evaluate[Evaluate<br/>Critic LLM]
+  Evaluate -->|"score + critique"| Decision{Score >=<br/>threshold?}
   Decision -->|"yes — accept"| Accept[Final Output]
-  Decision -->|"no — refine"| Critique[Critique\nStructured Feedback]
-  Critique -->|"feedback + draft"| Refine[Refine\nRevision LLM]
+  Decision -->|"no — refine"| Critique[Critique<br/>Structured Feedback]
+  Critique -->|"feedback + draft"| Refine[Refine<br/>Revision LLM]
   Refine -->|"revised output"| Evaluate
   Refine -->|"max iterations reached"| Accept
 ```

--- a/next/content/docs/pt-BR/agents/tools-actions.mdx
+++ b/next/content/docs/pt-BR/agents/tools-actions.mdx
@@ -35,10 +35,10 @@ APIs modernas de LLM suportam chamadas paralelas de ferramentas: o modelo pode s
 
 ```mermaid
 flowchart LR
-  User[User Message] -->|"message + tool schemas"| Agent[Agent / LLM\nReasoning]
-  Agent -->|"selects tool"| ToolSelection[Tool Selection\nFunction Call Object]
-  ToolSelection -->|"dispatch"| ToolExec[Tool Execution\nPython Function]
-  ToolExec -->|"calls"| External[External Service\nAPI / DB / Web]
+  User[User Message] -->|"message + tool schemas"| Agent[Agent / LLM<br/>Reasoning]
+  Agent -->|"selects tool"| ToolSelection[Tool Selection<br/>Function Call Object]
+  ToolSelection -->|"dispatch"| ToolExec[Tool Execution<br/>Python Function]
+  ToolExec -->|"calls"| External[External Service<br/>API / DB / Web]
   External -->|"raw result"| ToolExec
   ToolExec -->|"formatted result"| Agent
   Agent -->|"continue reasoning or answer"| Agent

--- a/next/content/docs/pt-BR/claude-code/claude-md.mdx
+++ b/next/content/docs/pt-BR/claude-code/claude-md.mdx
@@ -36,9 +36,9 @@ Como o `CLAUDE.md` é injetado em cada requisição, instruções desatualizadas
 
 ```mermaid
 flowchart LR
-  Global["~/.claude/CLAUDE.md\n(global)"] -->|loaded first| Merge[Merged system prompt]
-  Root["project-root/CLAUDE.md\n(project)"] -->|overrides global| Merge
-  Sub["src/feature/CLAUDE.md\n(subdirectory, optional)"] -->|narrowest scope| Merge
+  Global["~/.claude/CLAUDE.md<br/>(global)"] -->|loaded first| Merge[Merged system prompt]
+  Root["project-root/CLAUDE.md<br/>(project)"] -->|overrides global| Merge
+  Sub["src/feature/CLAUDE.md<br/>(subdirectory, optional)"] -->|narrowest scope| Merge
   Merge -->|injected into| Session[Claude Code session]
   Session -->|persistent for entire session| LLM[Claude model]
 ```

--- a/next/content/docs/pt-BR/claude-code/context-management.mdx
+++ b/next/content/docs/pt-BR/claude-code/context-management.mdx
@@ -42,7 +42,7 @@ flowchart LR
   FileRead[File contents loaded] -->|appended to history| History
   Assemble -->|sent to| Model[Claude model]
   Model -->|response + new tool calls| History
-  History -->|approaching limit| Compress[Auto-compression\nold turns summarized]
+  History -->|approaching limit| Compress[Auto-compression<br/>old turns summarized]
   Compress -->|trimmed history| Assemble
   Clear[/clear command] -->|resets| History
 ```

--- a/next/content/docs/pt-BR/claude-code/mcp-plugins.mdx
+++ b/next/content/docs/pt-BR/claude-code/mcp-plugins.mdx
@@ -36,11 +36,11 @@ Servidores MCP gerenciam sua própria autenticação. Um servidor MCP do GitHub,
 
 ```mermaid
 flowchart LR
-  Dev[Developer request] -->|natural language| ClaudeCode[Claude Code\nMCP client]
+  Dev[Developer request] -->|natural language| ClaudeCode[Claude Code<br/>MCP client]
   ClaudeCode -->|initialize + list tools| MCPServer[MCP Server]
   MCPServer -->|tool manifest| ClaudeCode
   ClaudeCode -->|tool call request| MCPServer
-  MCPServer -->|calls external service| External[External Service\ne.g. GitHub, DB, Jira]
+  MCPServer -->|calls external service| External[External Service<br/>e.g. GitHub, DB, Jira]
   External -->|response| MCPServer
   MCPServer -->|tool result| ClaudeCode
   ClaudeCode -->|result injected into context| Model[Claude model]

--- a/next/content/docs/pt-BR/claude-code/prompt-caching.mdx
+++ b/next/content/docs/pt-BR/claude-code/prompt-caching.mdx
@@ -37,9 +37,9 @@ A resposta da API inclui um objeto `usage` que distingue entre tokens de entrada
 ```mermaid
 flowchart LR
   Req1[First API request] -->|cache_control marker| Build[Build cache entry]
-  Build -->|stores KV state| Cache[Prompt cache\n5 min TTL]
-  Req2[Second API request\nsame prefix] -->|prefix matches| Hit[Cache hit]
-  Hit -->|skip reprocessing| Fast[Fast response\n0.1x token cost]
+  Build -->|stores KV state| Cache[Prompt cache<br/>5 min TTL]
+  Req2[Second API request<br/>same prefix] -->|prefix matches| Hit[Cache hit]
+  Hit -->|skip reprocessing| Fast[Fast response<br/>0.1x token cost]
   Req3[Request after 5 min idle] -->|cache expired| Miss[Cache miss]
   Miss -->|rebuild cache| Build
 ```

--- a/next/content/docs/pt-BR/cost-optimization/index.mdx
+++ b/next/content/docs/pt-BR/cost-optimization/index.mdx
@@ -22,14 +22,14 @@ O custo é determinado por quatro fatores: o número de **tokens de entrada** en
 
 ```mermaid
 flowchart LR
-  Request[Consulta recebida] --> Cache\{Cache semântico\nacerto?\}
-  Cache -->|Sim| Return[Retornar resposta em cache\n100% de economia]
-  Cache -->|Não| Router[Roteador de modelos\nclassificador de complexidade]
-  Router -->|simples| Cheap[Modelo pequeno\nex.: Haiku / GPT-4o-mini]
-  Router -->|complexo| Premium[Modelo premium\nex.: Opus / GPT-4o]
-  Cheap --> PromptCache\{Prefixo do prompt\nem cache?\}
+  Request[Consulta recebida] --> Cache\{Cache semântico<br/>acerto?\}
+  Cache -->|Sim| Return[Retornar resposta em cache<br/>100% de economia]
+  Cache -->|Não| Router[Roteador de modelos<br/>classificador de complexidade]
+  Router -->|simples| Cheap[Modelo pequeno<br/>ex.: Haiku / GPT-4o-mini]
+  Router -->|complexo| Premium[Modelo premium<br/>ex.: Opus / GPT-4o]
+  Cheap --> PromptCache\{Prefixo do prompt<br/>em cache?\}
   Premium --> PromptCache
-  PromptCache -->|Sim| Discount[Desconto de 90% no custo de entrada\nAnthropic / 50% OpenAI]
+  PromptCache -->|Sim| Discount[Desconto de 90% no custo de entrada<br/>Anthropic / 50% OpenAI]
   PromptCache -->|Não| Full[Inferência com preço integral]
   Discount --> Store[Armazenar no cache semântico]
   Full --> Store

--- a/next/content/docs/pt-BR/cost-optimization/model-tiering.mdx
+++ b/next/content/docs/pt-BR/cost-optimization/model-tiering.mdx
@@ -20,13 +20,13 @@ Dados da indústria de 2025–2026 mostram consistentemente que 50–70% das req
 
 ```mermaid
 flowchart TD
-  Query[Consulta recebida] --> SemCache\{Cache semântico\nacerto? cosseno ≥ 0,92\}
-  SemCache -->|Sim| CacheReturn[Retornar resposta em cache\n0 tokens consumidos]
-  SemCache -->|Não| Classifier[Classificador de complexidade\nmodelo pequeno / baseado em regras]
-  Classifier -->|pontuação ≤ 0,4\nsimples| Tier1[Nível 1 — modelo pequeno\nHaiku / GPT-4o-mini\n~$0,15/1M tokens]
-  Classifier -->|0,4–0,75\nmédio| Tier2[Nível 2 — modelo intermediário\nSonnet / GPT-4o\n~$3/1M tokens]
-  Classifier -->|pontuação > 0,75\ncomplexo| Tier3[Nível 3 — premium\nOpus / o3\n~$15/1M tokens]
-  Tier1 --> ConfCheck\{Confiança da saída\n≥ limiar?\}
+  Query[Consulta recebida] --> SemCache\{Cache semântico<br/>acerto? cosseno ≥ 0,92\}
+  SemCache -->|Sim| CacheReturn[Retornar resposta em cache<br/>0 tokens consumidos]
+  SemCache -->|Não| Classifier[Classificador de complexidade<br/>modelo pequeno / baseado em regras]
+  Classifier -->|pontuação ≤ 0,4<br/>simples| Tier1[Nível 1 — modelo pequeno<br/>Haiku / GPT-4o-mini<br/>~$0,15/1M tokens]
+  Classifier -->|0,4–0,75<br/>médio| Tier2[Nível 2 — modelo intermediário<br/>Sonnet / GPT-4o<br/>~$3/1M tokens]
+  Classifier -->|pontuação > 0,75<br/>complexo| Tier3[Nível 3 — premium<br/>Opus / o3<br/>~$15/1M tokens]
+  Tier1 --> ConfCheck\{Confiança da saída<br/>≥ limiar?\}
   ConfCheck -->|Não| Escalate[Escalar para Nível 2]
   ConfCheck -->|Sim| Store[Armazenar no cache semântico]
   Tier2 --> Store

--- a/next/content/docs/pt-BR/cost-optimization/prompt-caching.mdx
+++ b/next/content/docs/pt-BR/cost-optimization/prompt-caching.mdx
@@ -23,11 +23,11 @@ O cache de prompts oferece maior benefício quando o mesmo prefixo longo é reut
 
 ```mermaid
 flowchart LR
-  Request[Nova requisição\nsistema + docs + consulta do usuário] --> Split[Dividir no ponto de quebra de cache]
-  Split -->|Prefixo ≤ ponto de quebra| Check\{Acerto no\nKV-cache?\}
-  Split -->|Sufixo após ponto de quebra| Always[Sempre computado\npreço integral]
-  Check -->|Acerto| Cheap[Tokens em cache\n10% preço Anthropic\n50% preço OpenAI]
-  Check -->|Erro| Full[Preço integral\n+ taxa de escrita de cache]
+  Request[Nova requisição<br/>sistema + docs + consulta do usuário] --> Split[Dividir no ponto de quebra de cache]
+  Split -->|Prefixo ≤ ponto de quebra| Check\{Acerto no<br/>KV-cache?\}
+  Split -->|Sufixo após ponto de quebra| Always[Sempre computado<br/>preço integral]
+  Check -->|Acerto| Cheap[Tokens em cache<br/>10% preço Anthropic<br/>50% preço OpenAI]
+  Check -->|Erro| Full[Preço integral<br/>+ taxa de escrita de cache]
   Cheap --> Merge[Mesclar estados KV]
   Full --> Merge
   Always --> Merge

--- a/next/content/docs/pt-BR/cost-optimization/token-budgeting.mdx
+++ b/next/content/docs/pt-BR/cost-optimization/token-budgeting.mdx
@@ -18,14 +18,14 @@ Tokens de entrada incluem: o prompt de sistema, o histórico de conversa, o cont
 
 ```mermaid
 flowchart TD
-  Raw[Entradas brutas\nsistema + histórico + contexto + consulta] --> Compress[Compressão de prompt\nLLMLingua / sumarização seletiva]
-  Compress --> Trim[Cortador de contexto RAG\ntop-k chunks, limite de tokens]
-  Trim --> Prune[Podador de histórico\njanela deslizante / resumo abstrato]
-  Prune --> Budget\{Total de tokens\n≤ orçamento?\}
+  Raw[Entradas brutas<br/>sistema + histórico + contexto + consulta] --> Compress[Compressão de prompt<br/>LLMLingua / sumarização seletiva]
+  Compress --> Trim[Cortador de contexto RAG<br/>top-k chunks, limite de tokens]
+  Trim --> Prune[Podador de histórico<br/>janela deslizante / resumo abstrato]
+  Prune --> Budget\{Total de tokens<br/>≤ orçamento?\}
   Budget -->|Sim| LLM[Enviar ao LLM]
   Budget -->|Não| Drop[Descartar chunks de menor pontuação]
   Drop --> LLM
-  LLM --> MaxTok[max_tokens / sequência de parada\nrestrição de saída]
+  LLM --> MaxTok[max_tokens / sequência de parada<br/>restrição de saída]
   MaxTok --> Response[Resposta limitada]
 ```
 

--- a/next/content/docs/pt-BR/drl/index.mdx
+++ b/next/content/docs/pt-BR/drl/index.mdx
@@ -35,7 +35,7 @@ O Soft Actor-Critic (SAC) maximiza tanto a recompensa quanto a entropia da polí
 
 ```mermaid
 flowchart LR
-  Env[Ambiente] -->|estado s, recompensa r| Agent[Agente DRL\npolítica π_θ]
+  Env[Ambiente] -->|estado s, recompensa r| Agent[Agente DRL<br/>política π_θ]
   Agent -->|ação a| Env
   Agent -->|armazena transição| Buffer[Buffer de replay]
   Buffer -->|minilote| Train[Treinamento da rede neural]

--- a/next/content/docs/pt-BR/edge-ai/onnx.mdx
+++ b/next/content/docs/pt-BR/edge-ai/onnx.mdx
@@ -22,10 +22,10 @@ flowchart LR
   PyTorch["PyTorch Model"] -->|"torch.onnx.export()"| ONNX["ONNX Model (.onnx)"]
   TF["TensorFlow / Keras"] -->|"tf2onnx convert"| ONNX
   SKLearn["scikit-learn / XGBoost"] -->|"skl2onnx / onnxmltools"| ONNX
-  ONNX -->|"ort.InferenceSession()"| ORT["ONNX Runtime\nSession"]
-  ORT -->|"graph optimizations"| GraphOpt["Optimized Graph\n(fused ops, constants folded)"]
-  GraphOpt -->|"EP selection"| EP["Execution Provider\n(CPU / CUDA / TensorRT / CoreML / NNAPI)"]
-  EP -->|"kernel dispatch"| Device["Target Device\n(CPU, GPU, NPU)"]
+  ONNX -->|"ort.InferenceSession()"| ORT["ONNX Runtime<br/>Session"]
+  ORT -->|"graph optimizations"| GraphOpt["Optimized Graph<br/>(fused ops, constants folded)"]
+  GraphOpt -->|"EP selection"| EP["Execution Provider<br/>(CPU / CUDA / TensorRT / CoreML / NNAPI)"]
+  EP -->|"kernel dispatch"| Device["Target Device<br/>(CPU, GPU, NPU)"]
 ```
 
 ### Formato ONNX e interoperabilidade de modelos

--- a/next/content/docs/pt-BR/edge-ai/pytorch-mobile.mdx
+++ b/next/content/docs/pt-BR/edge-ai/pytorch-mobile.mdx
@@ -19,12 +19,12 @@ O Google e a Meta desenvolveram conjuntamente o **ExecuTorch** como o framework 
 
 ```mermaid
 flowchart LR
-  PyModel["PyTorch Model\n(nn.Module)"] -->|"torch.jit.trace / script"| TorchScript["TorchScript\nScriptModule"]
-  PyModel -->|"torch.export.export"| ExportedProgram["ExportedProgram\n(ATen IR)"]
+  PyModel["PyTorch Model<br/>(nn.Module)"] -->|"torch.jit.trace / script"| TorchScript["TorchScript<br/>ScriptModule"]
+  PyModel -->|"torch.export.export"| ExportedProgram["ExportedProgram<br/>(ATen IR)"]
   TorchScript -->|"optimize_for_mobile"| PTL[".ptl Bundle"]
-  ExportedProgram -->|"to_edge + link + serialize"| PTE[".pte Bundle\n(ExecuTorch)"]
-  PTL -->|"Module.load()"| LibTorch["LibTorch\nMobile Runtime"]
-  PTE -->|"Module::load()"| ETRuntime["ExecuTorch\nRuntime"]
+  ExportedProgram -->|"to_edge + link + serialize"| PTE[".pte Bundle<br/>(ExecuTorch)"]
+  PTL -->|"Module.load()"| LibTorch["LibTorch<br/>Mobile Runtime"]
+  PTE -->|"Module::load()"| ETRuntime["ExecuTorch<br/>Runtime"]
   LibTorch -->|"forward()"| Device["Android / iOS Device"]
   ETRuntime -->|"execute()"| Device
 ```

--- a/next/content/docs/pt-BR/edge-ai/tflite.mdx
+++ b/next/content/docs/pt-BR/edge-ai/tflite.mdx
@@ -22,7 +22,7 @@ flowchart LR
   TF["TensorFlow / Keras Model"] -->|"saved_model or .h5"| Converter["TFLite Converter"]
   Converter -->|"quantize / optimize"| FlatBuffer[".tflite FlatBuffer"]
   FlatBuffer -->|"load via Python / C++ / Java"| Interpreter["TFLite Interpreter"]
-  Interpreter -->|"delegate selection"| Delegate["Hardware Delegate\n(GPU / NNAPI / CoreML)"]
+  Interpreter -->|"delegate selection"| Delegate["Hardware Delegate<br/>(GPU / NNAPI / CoreML)"]
   Delegate -->|"accelerated kernels"| Device["Target Device"]
 ```
 

--- a/next/content/docs/pt-BR/edge-reasoning/index.mdx
+++ b/next/content/docs/pt-BR/edge-reasoning/index.mdx
@@ -31,7 +31,7 @@ Para conversas longas, os estados de chave-valor de atenção são armazenados e
 
 ```mermaid
 flowchart TD
-  Input[Prompt do usuário] --> Runtime[Tempo de execução de borda\nllama.cpp / ONNX / TFLite]
+  Input[Prompt do usuário] --> Runtime[Tempo de execução de borda<br/>llama.cpp / ONNX / TFLite]
   Runtime --> HW{Hardware disponível}
   HW -->|CPU| CPU[Kernel BLAS otimizado]
   HW -->|GPU| GPU[Metal / Vulkan]

--- a/next/content/docs/pt-BR/embeddings/fine-tuning-embeddings.mdx
+++ b/next/content/docs/pt-BR/embeddings/fine-tuning-embeddings.mdx
@@ -18,14 +18,14 @@ O objetivo de treinamento padrão é a **perda contrastiva** (InfoNCE / NT-Xent)
 
 ```mermaid
 flowchart TD
-  Data[Pares de treinamento\nconsulta + positivo + negativos difíceis] --> Tokenize[Tokenizar consulta e documento]
-  Tokenize --> Encoder[Passagem direta pelo encoder\npesos compartilhados]
+  Data[Pares de treinamento<br/>consulta + positivo + negativos difíceis] --> Tokenize[Tokenizar consulta e documento]
+  Tokenize --> Encoder[Passagem direta pelo encoder<br/>pesos compartilhados]
   Encoder --> Pool[Pooling médio → embedding]
-  Pool --> Loss[Perda contrastiva\nInfoNCE / MultipleNegativesRanking]
+  Pool --> Loss[Perda contrastiva<br/>InfoNCE / MultipleNegativesRanking]
   Loss --> Grad[Retropropagação]
-  Grad --> Update[Atualização de pesos\nAdamW + agenda de LR]
+  Grad --> Update[Atualização de pesos<br/>AdamW + agenda de LR]
   Update -->|repetir| Tokenize
-  Update -->|avaliar| BEIR[Avaliar em subconjunto BEIR / MTEB\nnDCG@10]
+  Update -->|avaliar| BEIR[Avaliar em subconjunto BEIR / MTEB<br/>nDCG@10]
 ```
 
 ### Dados de treinamento

--- a/next/content/docs/pt-BR/embeddings/index.mdx
+++ b/next/content/docs/pt-BR/embeddings/index.mdx
@@ -26,11 +26,11 @@ As propriedades-chave de um modelo de embedding são:
 ```mermaid
 flowchart LR
   Text[Texto de entrada] --> Tokenizer[Tokenizador]
-  Tokenizer --> Encoder[Encoder transformer\nBERT / RoBERTa / personalizado]
-  Encoder --> Pool[Pooling\nmédia / CLS / ponderado]
-  Pool --> Project[Projeção linear\nredução de dimensão opcional]
+  Tokenizer --> Encoder[Encoder transformer<br/>BERT / RoBERTa / personalizado]
+  Encoder --> Pool[Pooling<br/>média / CLS / ponderado]
+  Pool --> Project[Projeção linear<br/>redução de dimensão opcional]
   Project --> Norm[Normalização L2]
-  Norm --> Vector[Vetor de embedding\nex.: 1536-dim float32]
+  Norm --> Vector[Vetor de embedding<br/>ex.: 1536-dim float32]
 ```
 
 **Tokenizar:** o texto é dividido em subtokens. **Codificar:** um transformer processa todos os tokens em paralelo, produzindo representações contextuais dos tokens. **Fazer pooling:** as representações de tokens são agregadas em um único vetor de sentença (pooling médio é o mais comum para embeddings de sentença). **Projetar:** uma camada linear opcional reduz a dimensão (ex.: 768→256 para truncamento MRL). **Normalizar:** a normalização L2 permite que a similaridade de cosseno seja calculada como produto escalar.

--- a/next/content/docs/pt-BR/embeddings/late-interaction-colbert.mdx
+++ b/next/content/docs/pt-BR/embeddings/late-interaction-colbert.mdx
@@ -20,13 +20,13 @@ Em 2025, o **Jina ColBERT v2** estendeu a interação tardia para 89 idiomas com
 
 ```mermaid
 flowchart LR
-  Query[Consulta do usuário\n"melhores hotéis perto do\nrio E cobertura"] --> QEnc[Encoder de consulta\nBERT ajustado fino]
-  QEnc -->|Matriz Q\n32 × 128| MaxSim
+  Query[Consulta do usuário<br/>"melhores hotéis perto do<br/>rio E cobertura"] --> QEnc[Encoder de consulta<br/>BERT ajustado fino]
+  QEnc -->|Matriz Q<br/>32 × 128| MaxSim
 
-  Doc[Documento\n512 tokens] --> DEnc[Encoder de documento\npesos BERT compartilhados]
-  DEnc -->|Matriz D\n512 × 128| MaxSim
+  Doc[Documento<br/>512 tokens] --> DEnc[Encoder de documento<br/>pesos BERT compartilhados]
+  DEnc -->|Matriz D<br/>512 × 128| MaxSim
 
-  MaxSim[Operador MaxSim\npara cada q_i: máx sobre d_j sim q_i·d_j\nsomar todas as pontuações q] --> Score[Pontuação de relevância]
+  MaxSim[Operador MaxSim<br/>para cada q_i: máx sobre d_j sim q_i·d_j<br/>somar todas as pontuações q] --> Score[Pontuação de relevância]
   Score --> Rank[Resultados classificados]
 ```
 

--- a/next/content/docs/pt-BR/evals/eval-frameworks.mdx
+++ b/next/content/docs/pt-BR/evals/eval-frameworks.mdx
@@ -17,7 +17,7 @@ A escolha do framework correto depende do que está sendo avaliado: um template 
 
 ```mermaid
 flowchart LR
-  TestCases[Casos de teste\nprompts + saídas esperadas] --> Framework[Framework de eval]
+  TestCases[Casos de teste<br/>prompts + saídas esperadas] --> Framework[Framework de eval]
   Framework -->|executa inferência| App[Aplicação LLM]
   App -->|saídas| Scorer[Pontuadores de métricas]
   Scorer -->|baseado em regras| Rules[Exact match / regex / JSON schema]

--- a/next/content/docs/pt-BR/evals/llm-as-judge.mdx
+++ b/next/content/docs/pt-BR/evals/llm-as-judge.mdx
@@ -22,7 +22,7 @@ Três padrões dominantes emergiram:
 
 ```mermaid
 flowchart LR
-  Prompt[Prompt de avaliação\nrubric + saída candidata] --> Judge[LLM juiz]
+  Prompt[Prompt de avaliação<br/>rubric + saída candidata] --> Judge[LLM juiz]
   Judge -->|raciocínio chain-of-thought| CoT[Rastro de raciocínio]
   CoT -->|pontuação numérica ou veredito| Score[Pontuação / ranking]
   Score --> Aggregator[Agregador de pontuações]

--- a/next/content/docs/pt-BR/frameworks/index.mdx
+++ b/next/content/docs/pt-BR/frameworks/index.mdx
@@ -22,10 +22,10 @@ flowchart TD
   Task{Qual é seu objetivo principal?} -->|Pesquisa e iteração rápida| PT[PyTorch]
   Task -->|Pipelines de produção, mobile, TPUs| TF[TensorFlow / Keras]
 
-  PT -->|Treinamento| HF[HuggingFace Transformers\ntorchvision · torchaudio]
+  PT -->|Treinamento| HF[HuggingFace Transformers<br/>torchvision · torchaudio]
   PT -->|Implantação| PTD[TorchScript · ONNX · PyTorch Mobile]
 
-  TF -->|Treinamento| KR[API Keras\ntf.data · tf.distribute]
+  TF -->|Treinamento| KR[API Keras<br/>tf.data · tf.distribute]
   TF -->|Implantação| TFD[TF Serving · TFLite · TFX · TF Hub]
 
   HF -->|Enviar para produção| PTD

--- a/next/content/docs/pt-BR/frameworks/pytorch.mdx
+++ b/next/content/docs/pt-BR/frameworks/pytorch.mdx
@@ -17,10 +17,10 @@ O ecossistema do PyTorch inclui o TorchVision (modelos de visão computacional e
 
 ```mermaid
 flowchart LR
-  Data["Dados\n(Dataset + DataLoader)"] -->|"lotes"| Model["Modelo nn.Module"]
+  Data["Dados<br/>(Dataset + DataLoader)"] -->|"lotes"| Model["Modelo nn.Module"]
   Model -->|"forward pass"| Loss["Função de perda"]
-  Loss -->|"backward()"| Autograd["Motor autograd\n(calcula gradientes)"]
-  Autograd -->|"step()"| Optimizer["Otimizador\n(SGD, Adam, etc.)"]
+  Loss -->|"backward()"| Autograd["Motor autograd<br/>(calcula gradientes)"]
+  Autograd -->|"step()"| Optimizer["Otimizador<br/>(SGD, Adam, etc.)"]
   Optimizer -->|"atualiza pesos"| Model
 ```
 

--- a/next/content/docs/pt-BR/frameworks/tensorflow.mdx
+++ b/next/content/docs/pt-BR/frameworks/tensorflow.mdx
@@ -17,7 +17,7 @@ O ecossistema TensorFlow inclui: **TF Serving** para implantação de modelos em
 
 ```mermaid
 flowchart LR
-  Data["tf.data.Dataset"] -->|"lotes em pipeline"| Model["Modelo Keras\n(camadas Sequential / Functional)"]
+  Data["tf.data.Dataset"] -->|"lotes em pipeline"| Model["Modelo Keras<br/>(camadas Sequential / Functional)"]
   Model -->|"forward pass"| Loss["Função de perda"]
   Loss -->|"GradientTape / compile()"| Grads["Gradientes calculados"]
   Grads -->|"optimizer.apply()"| Weights["Pesos atualizados"]

--- a/next/content/docs/pt-BR/fundamentals/deep-learning.mdx
+++ b/next/content/docs/pt-BR/fundamentals/deep-learning.mdx
@@ -17,10 +17,10 @@ As arquiteturas de deep learning abrangem CNNs para visão, RNNs para sequência
 
 ```mermaid
 flowchart LR
-  RawData["Dados brutos\n(imagens, texto, áudio)"] -->|"extrair features brutas"| Layer1["Camada 1\n(features de baixo nível)"]
-  Layer1 -->|"combinar features"| Layer2["Camada 2\n(features de nível médio)"]
-  Layer2 -->|"abstrair ainda mais"| LayerN["Camada N\n(features abstratas)"]
-  LayerN -->|"prever"| Output["Saída\n(classe / token / valor)"]
+  RawData["Dados brutos<br/>(imagens, texto, áudio)"] -->|"extrair features brutas"| Layer1["Camada 1<br/>(features de baixo nível)"]
+  Layer1 -->|"combinar features"| Layer2["Camada 2<br/>(features de nível médio)"]
+  Layer2 -->|"abstrair ainda mais"| LayerN["Camada N<br/>(features abstratas)"]
+  LayerN -->|"prever"| Output["Saída<br/>(classe / token / valor)"]
   Output -->|"perda → gradientes"| RawData
 ```
 

--- a/next/content/docs/pt-BR/fundamentals/machine-learning.mdx
+++ b/next/content/docs/pt-BR/fundamentals/machine-learning.mdx
@@ -23,7 +23,7 @@ A maioria dos casos de uso de ML do dia a dia (spam, reconhecimento de imagens, 
 
 ```mermaid
 flowchart LR
-  Data["Dados\n(exemplos rotulados ou não)"] -->|"alimentar"| Model["Modelo\n(parâmetros aprendidos)"]
+  Data["Dados<br/>(exemplos rotulados ou não)"] -->|"alimentar"| Model["Modelo<br/>(parâmetros aprendidos)"]
   Model -->|"prever"| Prediction["Previsão / saída"]
   Prediction -->|"comparar com rótulo"| Loss["Sinal de perda / recompensa"]
   Loss -->|"atualizar parâmetros"| Model

--- a/next/content/docs/pt-BR/inference-optimization/index.mdx
+++ b/next/content/docs/pt-BR/inference-optimization/index.mdx
@@ -31,7 +31,7 @@ flowchart TD
   GPU -->|páginas KV| PagedKV[Pool de KV cache paginado]
   PagedKV -->|hit de prefixo| PrefixCache[Reutilização de prefix cache]
   PagedKV -->|novos tokens| Allocate[Alocar novos blocos]
-  GPU -->|tokens rascunho| SpecDec[Speculative decoding\nmodelo de rascunho]
+  GPU -->|tokens rascunho| SpecDec[Speculative decoding<br/>modelo de rascunho]
   SpecDec -->|verificar em paralelo| GPU
   GPU --> Output[Stream de tokens]
 ```

--- a/next/content/docs/pt-BR/inference-optimization/kv-cache.mdx
+++ b/next/content/docs/pt-BR/inference-optimization/kv-cache.mdx
@@ -20,8 +20,8 @@ O trade-off é a memória: o KV cache cresce linearmente com o comprimento do co
 
 ```mermaid
 flowchart LR
-  Prefill[Fase de prefill\ncomputa K,V para todos os tokens do prompt\narmazena no KV cache] --> Decode
-  Decode[Fase de decode\ncomputa K,V apenas para o novo token\nconsulta todos os K,V anteriores do cache] -->|próximo token| Decode
+  Prefill[Fase de prefill<br/>computa K,V para todos os tokens do prompt<br/>armazena no KV cache] --> Decode
+  Decode[Fase de decode<br/>computa K,V apenas para o novo token<br/>consulta todos os K,V anteriores do cache] -->|próximo token| Decode
   Decode -->|sequência completa| Evict[Despejar blocos do pool]
 ```
 

--- a/next/content/docs/pt-BR/inference-optimization/speculative-decoding.mdx
+++ b/next/content/docs/pt-BR/inference-optimization/speculative-decoding.mdx
@@ -20,8 +20,8 @@ O speculative decoding é **sem perdas por design**: nunca altera a distribuiç�
 
 ```mermaid
 flowchart LR
-  Prompt[Prompt\n+ contexto] -->|k forward passes| Draft[Modelo de rascunho\npropõe tokens t1...tk]
-  Draft -->|t1 t2 t3 t4| Target[Modelo alvo\nverifica todos os 4 em um pass]
+  Prompt[Prompt<br/>+ contexto] -->|k forward passes| Draft[Modelo de rascunho<br/>propõe tokens t1...tk]
+  Draft -->|t1 t2 t3 t4| Target[Modelo alvo<br/>verifica todos os 4 em um pass]
   Target -->|aceita t1 t2 t3| Accepted[Aceitar 3 tokens]
   Target -->|rejeita t4, reamostra| Resampled[Reamostrar t4 do alvo]
   Accepted & Resampled --> Output[Saída: 4 tokens em ~2 passes do alvo]

--- a/next/content/docs/pt-BR/inference-optimization/vllm.mdx
+++ b/next/content/docs/pt-BR/inference-optimization/vllm.mdx
@@ -21,8 +21,8 @@ As implementações de atenção tradicionais requerem uma região de memória c
 
 ```mermaid
 flowchart LR
-  Seq1[Sequência A\ntabela de blocos: 0→3, 1→7] -->|consulta| Pool[Pool físico de blocos KV\n0 1 2 3 4 5 6 7 ...]
-  Seq2[Sequência B\ntabela de blocos: 0→1, 1→5] -->|consulta| Pool
+  Seq1[Sequência A<br/>tabela de blocos: 0→3, 1→7] -->|consulta| Pool[Pool físico de blocos KV<br/>0 1 2 3 4 5 6 7 ...]
+  Seq2[Sequência B<br/>tabela de blocos: 0→1, 1→5] -->|consulta| Pool
   Seq3[Prefixo compartilhado da Sequência C] -->|copy-on-write| Pool
 ```
 

--- a/next/content/docs/pt-BR/llms/fine-tuning.mdx
+++ b/next/content/docs/pt-BR/llms/fine-tuning.mdx
@@ -17,8 +17,8 @@ O fine-tuning resolve limitações do prompting: pode ensinar o modelo a adotar 
 
 ```mermaid
 flowchart LR
-  PreTrained["Modelo pré-treinado\n(base ou ajustado por instrução)"] -->|"carregar"| FTSetup["Configuração de fine-tuning\n(PEFT / full)"]
-  Dataset["Conjunto de dados de fine-tuning\n(pares instrução-resposta)"] -->|"formatar + tokenizar"| FTSetup
+  PreTrained["Modelo pré-treinado<br/>(base ou ajustado por instrução)"] -->|"carregar"| FTSetup["Configuração de fine-tuning<br/>(PEFT / full)"]
+  Dataset["Conjunto de dados de fine-tuning<br/>(pares instrução-resposta)"] -->|"formatar + tokenizar"| FTSetup
   FTSetup -->|"treinar em lotes"| FineTuned["Modelo ajustado"]
   FineTuned -->|"avaliar em validação"| Eval["Métricas de avaliação"]
   Eval -->|"suficientemente bom?"| Deploy["Implantação"]

--- a/next/content/docs/pt-BR/llms/index.mdx
+++ b/next/content/docs/pt-BR/llms/index.mdx
@@ -18,8 +18,8 @@ Modelos como GPT-4 (OpenAI), Claude (Anthropic), Gemini (Google) e Llama (Meta) 
 ```mermaid
 flowchart LR
   Prompt["Prompt do usuário"] -->|"tokenizar"| Tokens["Sequência de tokens"]
-  Tokens -->|"embeddings + posição"| Layers["N camadas Transformer\n(atenção + FFN)"]
-  Layers -->|"logits"| Sampling["Amostragem\n(temperatura, top-p, top-k)"]
+  Tokens -->|"embeddings + posição"| Layers["N camadas Transformer<br/>(atenção + FFN)"]
+  Layers -->|"logits"| Sampling["Amostragem<br/>(temperatura, top-p, top-k)"]
   Sampling -->|"próximo token"| Tokens
   Sampling -->|"token EOS"| Response["Resposta completa"]
 ```

--- a/next/content/docs/pt-BR/llms/post-training.mdx
+++ b/next/content/docs/pt-BR/llms/post-training.mdx
@@ -77,7 +77,7 @@ Isso elimina completamente o crítico (função de valor) — as estatísticas d
 ```mermaid
 flowchart TD
   P[Prompt] --> S[Sample group of N responses]
-  S --> R[Score each with verifiable reward\ne.g. math checker / code runner]
+  S --> R[Score each with verifiable reward<br/>e.g. math checker / code runner]
   R --> A[Compute group-normalized advantages]
   A --> G[Clipped policy gradient update]
   G --> P2[Updated policy]
@@ -101,9 +101,9 @@ O DAPO permite treinamento estável em escalas onde o GRPO diverge, e foi adotad
 
 ```mermaid
 flowchart LR
-  PT[Pretrained base model] --> SFT[SFT\nInstruction format]
-  SFT --> PREF[Preference optimization\nRLHF · DPO · ORPO]
-  PREF --> RLVR[RL with verifiable rewards\nGRPO · DAPO]
+  PT[Pretrained base model] --> SFT[SFT<br/>Instruction format]
+  SFT --> PREF[Preference optimization<br/>RLHF · DPO · ORPO]
+  PREF --> RLVR[RL with verifiable rewards<br/>GRPO · DAPO]
   RLVR --> Final[Aligned + reasoning model]
 ```
 

--- a/next/content/docs/pt-BR/llms/streaming.mdx
+++ b/next/content/docs/pt-BR/llms/streaming.mdx
@@ -17,7 +17,7 @@ As APIs de LLM implementam o streaming via **Server-Sent Events (SSE)** ou respo
 
 ```mermaid
 flowchart LR
-  Client["Cliente"] -->|"POST /v1/messages\nstream: true"| API["API do LLM"]
+  Client["Cliente"] -->|"POST /v1/messages<br/>stream: true"| API["API do LLM"]
   API -->|"SSE: data: {delta: 'Ol'}"| Client
   API -->|"SSE: data: {delta: 'á'}"| Client
   API -->|"SSE: data: {delta: '!'}"| Client

--- a/next/content/docs/pt-BR/mcp/building-clients.mdx
+++ b/next/content/docs/pt-BR/mcp/building-clients.mdx
@@ -42,7 +42,7 @@ A escolha do transporte depende de onde o servidor está sendo executado. O **tr
 flowchart LR
   HostApp["Host Application"]
   Client["MCP Client"]
-  Transport["Transport Layer\n(stdio or HTTP/SSE)"]
+  Transport["Transport Layer<br/>(stdio or HTTP/SSE)"]
   Server["MCP Server"]
 
   HostApp -->|"1. create client + connect"| Client

--- a/next/content/docs/pt-BR/mcp/building-servers.mdx
+++ b/next/content/docs/pt-BR/mcp/building-servers.mdx
@@ -45,10 +45,10 @@ A camada de transporte determina como o servidor se comunica com os clientes. O 
 flowchart TB
   Client["MCP Client"]
   Server["MCP Server Process"]
-  ToolReg["Tool Registry\n(get_forecast, read_file, ...)"]
-  ResourceReg["Resource Registry\n(file:///, db:///...)"]
-  PromptReg["Prompt Registry\n(query_builder, summarize, ...)"]
-  External["External Systems\n(APIs, DBs, File System)"]
+  ToolReg["Tool Registry<br/>(get_forecast, read_file, ...)"]
+  ResourceReg["Resource Registry<br/>(file:///, db:///...)"]
+  PromptReg["Prompt Registry<br/>(query_builder, summarize, ...)"]
+  External["External Systems<br/>(APIs, DBs, File System)"]
 
   Client -->|"initialize handshake"| Server
   Server -->|"capabilities response"| Client

--- a/next/content/docs/pt-BR/mcp/index.mdx
+++ b/next/content/docs/pt-BR/mcp/index.mdx
@@ -24,13 +24,13 @@ O MCP segue um modelo estrito de cliente-servidor com três papéis distintos. A
 
 ```mermaid
 flowchart LR
-  HostApp["Host Application\n(AI App / Agent)"]
+  HostApp["Host Application<br/>(AI App / Agent)"]
   Client1["MCP Client A"]
   Client2["MCP Client B"]
-  Server1["MCP Server A\n(File System)"]
-  Server2["MCP Server B\n(Weather API)"]
-  Tools1["Tools / Resources\n(read_file, list_dir)"]
-  Tools2["Tools / Resources\n(get_forecast, get_alerts)"]
+  Server1["MCP Server A<br/>(File System)"]
+  Server2["MCP Server B<br/>(Weather API)"]
+  Tools1["Tools / Resources<br/>(read_file, list_dir)"]
+  Tools2["Tools / Resources<br/>(get_forecast, get_alerts)"]
 
   HostApp -->|"embeds"| Client1
   HostApp -->|"embeds"| Client2

--- a/next/content/docs/pt-BR/mlops/cicd/dvc.mdx
+++ b/next/content/docs/pt-BR/mlops/cicd/dvc.mdx
@@ -19,11 +19,11 @@ O DVC se integra estreitamente com os fluxos de trabalho do Git. Um arquivo `dvc
 
 ```mermaid
 flowchart LR
-  Code["Code & Config\n(Git)"] -->|"dvc repro"| Pipeline["DVC Pipeline\n(dvc.yaml)"]
+  Code["Code & Config<br/>(Git)"] -->|"dvc repro"| Pipeline["DVC Pipeline<br/>(dvc.yaml)"]
   Pipeline -->|"runs stage"| Train["Training Stage"]
-  Train -->|"produces artifact"| Artifact["model artifact\n(local cache)"]
-  Artifact -->|"dvc push"| Remote["Remote Storage\n(S3 / GCS / Azure)"]
-  Remote -->|"dvc pull"| Colleague["Colleague's machine\nor CI runner"]
+  Train -->|"produces artifact"| Artifact["model artifact<br/>(local cache)"]
+  Artifact -->|"dvc push"| Remote["Remote Storage<br/>(S3 / GCS / Azure)"]
+  Remote -->|"dvc pull"| Colleague["Colleague's machine<br/>or CI runner"]
   Artifact -->|"pointer .dvc file"| Git["Git repository"]
   Git -->|"git checkout"| Colleague
 ```

--- a/next/content/docs/pt-BR/mlops/cicd/model-registry.mdx
+++ b/next/content/docs/pt-BR/mlops/cicd/model-registry.mdx
@@ -21,10 +21,10 @@ Os registros de modelos se integram tanto ao lado de treinamento (rastreadores d
 
 ```mermaid
 flowchart LR
-  Experiment["Training Run\n(MLflow / W&B)"] -->|"log + register artifact"| Registry["Model Registry\n(versioned catalog)"]
-  Registry -->|"promote to Staging"| Staging["Staging Environment\n(shadow traffic / A/B)"]
+  Experiment["Training Run<br/>(MLflow / W&B)"] -->|"log + register artifact"| Registry["Model Registry<br/>(versioned catalog)"]
+  Registry -->|"promote to Staging"| Staging["Staging Environment<br/>(shadow traffic / A/B)"]
   Staging -->|"approval / quality gate"| Production["Production Deployment"]
-  Production -->|"new version available"| Archived["Archived\n(old version)"]
+  Production -->|"new version available"| Archived["Archived<br/>(old version)"]
   CI["CI/CD Pipeline"] -->|"fetch latest Production model"| Production
   Registry -->|"webhook / event"| CI
 ```

--- a/next/content/docs/pt-BR/mlops/data-engineering/airflow.mdx
+++ b/next/content/docs/pt-BR/mlops/data-engineering/airflow.mdx
@@ -33,12 +33,12 @@ Com `KubernetesExecutor`, cada instância de tarefa obtém seu próprio pod Kube
 
 ```mermaid
 flowchart LR
-  DagFile["DAG file\n(Python)"] -- "parsed by" --> Scheduler["Scheduler"]
-  Scheduler -- "dispatches task" --> Executor["Executor\n(Celery / K8s)"]
+  DagFile["DAG file<br/>(Python)"] -- "parsed by" --> Scheduler["Scheduler"]
+  Scheduler -- "dispatches task" --> Executor["Executor<br/>(Celery / K8s)"]
   Executor -- "runs on" --> Worker["Worker / Pod"]
-  Worker -- "writes state" --> MetaDB["Metadata DB\n(PostgreSQL)"]
+  Worker -- "writes state" --> MetaDB["Metadata DB<br/>(PostgreSQL)"]
   MetaDB -- "read by" --> WebUI["Web UI"]
-  Worker -- "logs" --> LogStore["Log store\n(S3 / GCS)"]
+  Worker -- "logs" --> LogStore["Log store<br/>(S3 / GCS)"]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/mlops/data-engineering/index.mdx
+++ b/next/content/docs/pt-BR/mlops/data-engineering/index.mdx
@@ -33,10 +33,10 @@ Verificações de qualidade de dados devem ser incorporadas em cada estágio da 
 
 ```mermaid
 flowchart LR
-  Sources["Sources\n(DB / API / Events)"] -- "raw records" --> Ingest["Ingest\n(Extract & Load)"]
-  Ingest -- "raw data" --> Transform["Transform\n(Clean / Validate / Feature eng.)"]
-  Transform -- "validated features" --> Store["Store\n(Warehouse / Feature store)"]
-  Store -- "query / serve" --> Serve["Serve\n(Training / Inference)"]
+  Sources["Sources<br/>(DB / API / Events)"] -- "raw records" --> Ingest["Ingest<br/>(Extract & Load)"]
+  Ingest -- "raw data" --> Transform["Transform<br/>(Clean / Validate / Feature eng.)"]
+  Transform -- "validated features" --> Store["Store<br/>(Warehouse / Feature store)"]
+  Store -- "query / serve" --> Serve["Serve<br/>(Training / Inference)"]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/mlops/data-engineering/kafka.mdx
+++ b/next/content/docs/pt-BR/mlops/data-engineering/kafka.mdx
@@ -29,12 +29,12 @@ Um **consumidor** lê registros de uma ou mais partições. Os consumidores se o
 
 ```mermaid
 flowchart LR
-  Producer["Producer\n(App / IoT / DB CDC)"] -- "publish events" --> Topic["Kafka Topic\n(partitioned, replicated)"]
-  Topic -- "consume raw events" --> StreamProcessor["Stream Processor\n(Spark / Flink / Kafka Streams)"]
-  StreamProcessor -- "write features" --> FeatureStore["Online Feature Store\n(Feast / Redis)"]
-  FeatureStore -- "low-latency read" --> ModelServer["Model Server\n(REST / gRPC)"]
+  Producer["Producer<br/>(App / IoT / DB CDC)"] -- "publish events" --> Topic["Kafka Topic<br/>(partitioned, replicated)"]
+  Topic -- "consume raw events" --> StreamProcessor["Stream Processor<br/>(Spark / Flink / Kafka Streams)"]
+  StreamProcessor -- "write features" --> FeatureStore["Online Feature Store<br/>(Feast / Redis)"]
+  FeatureStore -- "low-latency read" --> ModelServer["Model Server<br/>(REST / gRPC)"]
   ModelServer -- "publish predictions" --> PredictionTopic["Prediction Topic"]
-  PredictionTopic -- "consume" --> Consumer["Consumer\n(Monitoring / Downstream app)"]
+  PredictionTopic -- "consume" --> Consumer["Consumer<br/>(Monitoring / Downstream app)"]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/mlops/data-engineering/spark.mdx
+++ b/next/content/docs/pt-BR/mlops/data-engineering/spark.mdx
@@ -33,11 +33,11 @@ Uma aplicação Spark tem um processo **driver** e um ou mais processos **execut
 
 ```mermaid
 flowchart LR
-  UserCode["User code\n(PySpark)"] -- "submits application" --> Driver["Driver\n(SparkContext)"]
-  Driver -- "requests resources" --> ClusterManager["Cluster Manager\n(YARN / K8s)"]
-  ClusterManager -- "allocates" --> Executors["Executors\n(Worker nodes)"]
+  UserCode["User code<br/>(PySpark)"] -- "submits application" --> Driver["Driver<br/>(SparkContext)"]
+  Driver -- "requests resources" --> ClusterManager["Cluster Manager<br/>(YARN / K8s)"]
+  ClusterManager -- "allocates" --> Executors["Executors<br/>(Worker nodes)"]
   Driver -- "sends tasks" --> Executors
-  Executors -- "read / write data" --> Storage["Storage\n(HDFS / S3 / Delta)"]
+  Executors -- "read / write data" --> Storage["Storage<br/>(HDFS / S3 / Delta)"]
   Executors -- "return results" --> Driver
 ```
 

--- a/next/content/docs/pt-BR/mlops/deployment/kubeflow.mdx
+++ b/next/content/docs/pt-BR/mlops/deployment/kubeflow.mdx
@@ -19,15 +19,15 @@ O ponto forte do KubeFlow é que ele roda em qualquer cluster Kubernetes — on-
 
 ```mermaid
 flowchart TB
-  Developer["Data Scientist\n(Jupyter / SDK)"] -->|"define pipeline"| KFP["KubeFlow Pipelines\n(KFP)"]
-  KFP -->|"schedules pods"| K8s["Kubernetes\n(control plane)"]
-  K8s -->|"run training job"| TrainPod["Training Pod\n(GPU node pool)"]
-  TrainPod -->|"log metrics"| Katib["Katib\n(hyperparameter tuning)"]
+  Developer["Data Scientist<br/>(Jupyter / SDK)"] -->|"define pipeline"| KFP["KubeFlow Pipelines<br/>(KFP)"]
+  KFP -->|"schedules pods"| K8s["Kubernetes<br/>(control plane)"]
+  K8s -->|"run training job"| TrainPod["Training Pod<br/>(GPU node pool)"]
+  TrainPod -->|"log metrics"| Katib["Katib<br/>(hyperparameter tuning)"]
   Katib -->|"suggest next trial"| TrainPod
-  TrainPod -->|"push artifact"| Storage["Model Store\n(S3 / GCS / MinIO)"]
-  Storage -->|"register model"| KFServe["KServe\n(model serving)"]
+  TrainPod -->|"push artifact"| Storage["Model Store<br/>(S3 / GCS / MinIO)"]
+  Storage -->|"register model"| KFServe["KServe<br/>(model serving)"]
   KFServe -->|"expose endpoint"| Client["Prediction Clients"]
-  KFP -->|"emit events"| Dashboard["KubeFlow Dashboard\n(UI + RBAC)"]
+  KFP -->|"emit events"| Dashboard["KubeFlow Dashboard<br/>(UI + RBAC)"]
 ```
 
 ### KubeFlow Pipelines (KFP)

--- a/next/content/docs/pt-BR/mlops/deployment/ml-kubernetes.mdx
+++ b/next/content/docs/pt-BR/mlops/deployment/ml-kubernetes.mdx
@@ -19,15 +19,15 @@ A diferença essencial em relação à execução de ML em VMs bare-metal é que
 
 ```mermaid
 flowchart TB
-  Developer["Data Scientist\n(writes Dockerfile + YAML)"] -->|"docker build + push"| Registry["Container Registry\n(ECR / GCR / GHCR)"]
+  Developer["Data Scientist<br/>(writes Dockerfile + YAML)"] -->|"docker build + push"| Registry["Container Registry<br/>(ECR / GCR / GHCR)"]
   Registry -->|"image pull"| K8s["Kubernetes Cluster"]
-  K8s -->|"schedule on GPU node"| TrainJob["Training Job\n(K8s Job)"]
-  K8s -->|"scale replicas"| ServingDeploy["Serving Deployment\n(K8s Deployment + HPA)"]
+  K8s -->|"schedule on GPU node"| TrainJob["Training Job<br/>(K8s Job)"]
+  K8s -->|"scale replicas"| ServingDeploy["Serving Deployment<br/>(K8s Deployment + HPA)"]
   ServingDeploy -->|"expose externally"| Ingress["Ingress / LoadBalancer"]
   Ingress -->|"traffic"| Client["Client"]
-  TrainJob -->|"write artifacts"| PVC["Persistent Volume\nor Object Storage"]
+  TrainJob -->|"write artifacts"| PVC["Persistent Volume<br/>or Object Storage"]
   PVC -->|"model load"| ServingDeploy
-  K8s -->|"GPU request"| GPUNode["GPU Node Pool\n(nvidia.com/gpu resource)"]
+  K8s -->|"GPU request"| GPUNode["GPU Node Pool<br/>(nvidia.com/gpu resource)"]
 ```
 
 ### Containerização de modelos de ML

--- a/next/content/docs/pt-BR/mlops/deployment/model-serving.mdx
+++ b/next/content/docs/pt-BR/mlops/deployment/model-serving.mdx
@@ -19,14 +19,14 @@ O escalonamento de um sistema de serviço de modelos envolve desafios específic
 
 ```mermaid
 flowchart LR
-  Client["Client\n(mobile / web / service)"] -->|"HTTPS request"| Gateway["API Gateway\n(rate limit, auth)"]
-  Gateway -->|"route request"| Server["Model Server\n(TorchServe / Triton / BentoML)"]
-  Server -->|"load model"| Store["Model Store\n(S3 / registry)"]
-  Server -->|"batched GPU calls"| GPU["GPU / CPU\n(inference worker)"]
+  Client["Client<br/>(mobile / web / service)"] -->|"HTTPS request"| Gateway["API Gateway<br/>(rate limit, auth)"]
+  Gateway -->|"route request"| Server["Model Server<br/>(TorchServe / Triton / BentoML)"]
+  Server -->|"load model"| Store["Model Store<br/>(S3 / registry)"]
+  Server -->|"batched GPU calls"| GPU["GPU / CPU<br/>(inference worker)"]
   GPU -->|"prediction"| Server
   Server -->|"JSON response"| Gateway
   Gateway -->|"response"| Client
-  Server -->|"metrics"| Monitor["Monitoring\n(latency, throughput)"]
+  Server -->|"metrics"| Monitor["Monitoring<br/>(latency, throughput)"]
 ```
 
 ### Inferência em lote

--- a/next/content/docs/pt-BR/mlops/feature-stores.mdx
+++ b/next/content/docs/pt-BR/mlops/feature-stores.mdx
@@ -39,13 +39,13 @@ A materialização é o processo de executar os pipelines de transformação e g
 
 ```mermaid
 flowchart LR
-  RawData[Raw data sources\nDB / data lake / streams] -->|"batch ETL"| OfflineStore[(Offline store\nBigQuery / S3 Parquet)]
-  RawData -->|"stream pipeline"| OnlineStore[(Online store\nRedis / DynamoDB)]
+  RawData[Raw data sources<br/>DB / data lake / streams] -->|"batch ETL"| OfflineStore[(Offline store<br/>BigQuery / S3 Parquet)]
+  RawData -->|"stream pipeline"| OnlineStore[(Online store<br/>Redis / DynamoDB)]
   OfflineStore -->|"point-in-time join"| TrainingData[Training dataset]
   TrainingData -->|"train model"| Model[ML model]
   OnlineStore -->|"low-latency lookup"| Serving[Inference serving]
   Model -->|"deploy"| Serving
-  FeatureDefs[Feature definitions\nPython / YAML] -->|"define transforms"| OfflineStore
+  FeatureDefs[Feature definitions<br/>Python / YAML] -->|"define transforms"| OfflineStore
   FeatureDefs -->|"define transforms"| OnlineStore
 ```
 

--- a/next/content/docs/pt-BR/mlops/iac/ansible.mdx
+++ b/next/content/docs/pt-BR/mlops/iac/ansible.mdx
@@ -40,13 +40,13 @@ Os módulos do Ansible são projetados para ser idempotentes: executar um playbo
 
 ```mermaid
 flowchart LR
-  ControlNode[Control node\nAnsible CLI] -->|"parse inventory"| Inventory[Inventory\nstatic / dynamic]
-  Inventory -->|"resolve target hosts"| Hosts[Target hosts\nGPU training nodes]
-  ControlNode -->|"read playbook"| Playbook[Playbook\n.yml tasks & roles]
+  ControlNode[Control node<br/>Ansible CLI] -->|"parse inventory"| Inventory[Inventory<br/>static / dynamic]
+  Inventory -->|"resolve target hosts"| Hosts[Target hosts<br/>GPU training nodes]
+  ControlNode -->|"read playbook"| Playbook[Playbook<br/>.yml tasks & roles]
   Playbook -->|"SSH connection"| Hosts
-  Hosts -->|"execute modules"| Tasks[Task execution\ninstall CUDA, pip, config]
-  Tasks -->|"notify on change"| Handlers[Handlers\nrestart services]
-  Tasks -->|"report status"| Summary[Run summary\nok / changed / failed]
+  Hosts -->|"execute modules"| Tasks[Task execution<br/>install CUDA, pip, config]
+  Tasks -->|"notify on change"| Handlers[Handlers<br/>restart services]
+  Tasks -->|"report status"| Summary[Run summary<br/>ok / changed / failed]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/mlops/iac/terraform.mdx
+++ b/next/content/docs/pt-BR/mlops/iac/terraform.mdx
@@ -37,11 +37,11 @@ Executar `terraform init` baixa os provedores e módulos necessários e iniciali
 
 ```mermaid
 flowchart LR
-  HCL[HCL configuration\n.tf files] -->|"terraform init"| Init[Provider & module\ndownload]
-  Init -->|"terraform plan"| Plan[Execution plan\ndiff against state]
+  HCL[HCL configuration<br/>.tf files] -->|"terraform init"| Init[Provider & module<br/>download]
+  Init -->|"terraform plan"| Plan[Execution plan<br/>diff against state]
   Plan -->|"human review / CI approval"| Apply[terraform apply]
-  Apply -->|"API calls"| Cloud[Cloud provider APIs\nAWS / GCP / Azure]
-  Cloud -->|"resource IDs"| State[State file\nS3 / GCS backend]
+  Apply -->|"API calls"| Cloud[Cloud provider APIs<br/>AWS / GCP / Azure]
+  Cloud -->|"resource IDs"| State[State file<br/>S3 / GCS backend]
   State -->|"next plan reads state"| Plan
 ```
 

--- a/next/content/docs/pt-BR/mlops/mlflow.mdx
+++ b/next/content/docs/pt-BR/mlops/mlflow.mdx
@@ -36,8 +36,8 @@ O registro armazena versões de modelos com nome e estados de transição. Siste
 ```mermaid
 flowchart LR
   Code[Training code] -->|"mlflow.start_run()"| Run[Active run]
-  Run -->|"log_params / log_metrics"| Backend[(Backend store\nSQLite / Postgres)]
-  Run -->|"log_artifact / log_model"| ArtStore[(Artifact store\nS3 / GCS / local)]
+  Run -->|"log_params / log_metrics"| Backend[(Backend store<br/>SQLite / Postgres)]
+  Run -->|"log_artifact / log_model"| ArtStore[(Artifact store<br/>S3 / GCS / local)]
   Backend -->|"query"| UI[MLflow UI]
   ArtStore -->|"retrieve"| UI
   UI -->|"register_model"| Registry[Model Registry]

--- a/next/content/docs/pt-BR/mlops/monitoring/grafana.mdx
+++ b/next/content/docs/pt-BR/mlops/monitoring/grafana.mdx
@@ -40,12 +40,12 @@ O Grafana suporta provisionamento declarativo de fontes de dados, dashboards e r
 
 ```mermaid
 flowchart LR
-  PrometheusDS[Prometheus\ndata source] -->|"PromQL query"| GrafanaQuery[Grafana query engine]
-  SQLDB[SQL / InfluxDB\ndata source] -->|"SQL / Flux query"| GrafanaQuery
-  GrafanaQuery -->|"normalized data frames"| Panels[Dashboard panels\ntime series, gauges, tables]
-  Panels -->|"rendered in browser"| Users[Data scientists /\nML engineers]
+  PrometheusDS[Prometheus<br/>data source] -->|"PromQL query"| GrafanaQuery[Grafana query engine]
+  SQLDB[SQL / InfluxDB<br/>data source] -->|"SQL / Flux query"| GrafanaQuery
+  GrafanaQuery -->|"normalized data frames"| Panels[Dashboard panels<br/>time series, gauges, tables]
+  Panels -->|"rendered in browser"| Users[Data scientists /<br/>ML engineers]
   GrafanaQuery -->|"evaluate alert rule"| AlertEngine[Grafana alert engine]
-  AlertEngine -->|"route notification"| ContactPoints[Slack / PagerDuty /\nemail]
+  AlertEngine -->|"route notification"| ContactPoints[Slack / PagerDuty /<br/>email]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/mlops/monitoring/prometheus.mdx
+++ b/next/content/docs/pt-BR/mlops/monitoring/prometheus.mdx
@@ -40,8 +40,8 @@ Para cenários multi-cluster ou de longa retenção, o Prometheus faz remote-wri
 
 ```mermaid
 flowchart LR
-  Targets[Instrumented targets\nML serving / training jobs] -->|"HTTP scrape /metrics"| Scrape[Prometheus scrape engine]
-  Scrape -->|"write samples"| TSDB[Time-series database\nlocal TSDB]
+  Targets[Instrumented targets<br/>ML serving / training jobs] -->|"HTTP scrape /metrics"| Scrape[Prometheus scrape engine]
+  Scrape -->|"write samples"| TSDB[Time-series database<br/>local TSDB]
   TSDB -->|"evaluate PromQL rules"| AlertRules[Alerting rules engine]
   AlertRules -->|"fire alert"| Alertmanager[Alertmanager]
   Alertmanager -->|"route notification"| Receivers[Slack / PagerDuty / email]

--- a/next/content/docs/pt-BR/model-providers/anthropic.mdx
+++ b/next/content/docs/pt-BR/model-providers/anthropic.mdx
@@ -32,7 +32,7 @@ A Messages API (`POST /v1/messages`) é a interface principal da Anthropic. Ao c
 ```mermaid
 flowchart LR
   Client[Client app] -->|POST /v1/messages| API[Anthropic API]
-  API -->|system + messages| Selector{Model\nselector}
+  API -->|system + messages| Selector{Model<br/>selector}
   Selector -->|complex reasoning| Opus[Claude Opus 4.7]
   Selector -->|balanced| Sonnet[Claude Sonnet 4.6]
   Selector -->|fast / cheap| Haiku[Claude Haiku 4.5]
@@ -40,7 +40,7 @@ flowchart LR
   Sonnet --> Resp
   Haiku --> Resp
   Resp --> Client
-  Resp -.->|token usage,\nbilling| Platform[Anthropic platform]
+  Resp -.->|token usage,<br/>billing| Platform[Anthropic platform]
 ```
 
 ### Tool use
@@ -50,8 +50,8 @@ O tool use permite ao Claude chamar funções externas emitindo blocos de conte�
 ```mermaid
 flowchart LR
   UserMsg[User message] --> Claude[Claude model]
-  Claude -->|emits tool_use block| ToolReq[Tool request\nname + input JSON]
-  ToolReq -->|your code invokes| ExtSystem[External system\nor function]
+  Claude -->|emits tool_use block| ToolReq[Tool request<br/>name + input JSON]
+  ToolReq -->|your code invokes| ExtSystem[External system<br/>or function]
   ExtSystem -->|result| ToolResult[tool_result message]
   ToolResult --> Claude
   Claude -->|final text response| UserMsg
@@ -73,7 +73,7 @@ Claude Opus 4.7 e Sonnet 4.6 suportam janela de contexto de 1M de tokens, e Haik
 
 ```mermaid
 flowchart LR
-  LargeDoc[Large document\nor codebase] -->|tokenize| Tokens[Up to 1M tokens]
+  LargeDoc[Large document<br/>or codebase] -->|tokenize| Tokens[Up to 1M tokens]
   Tokens -->|single API call| Claude[Claude model]
   SystemPrompt[System prompt] -->|cached prefix| Cache[(Prompt cache)]
   Cache -->|cache hit: 90% cheaper| Claude

--- a/next/content/docs/pt-BR/model-providers/cohere.mdx
+++ b/next/content/docs/pt-BR/model-providers/cohere.mdx
@@ -74,14 +74,14 @@ A integração RAG da Cohere une Embed, Rerank e Command A em um pipeline unific
 
 ```mermaid
 flowchart LR
-  Q[User Query] -->|embed with\nsearch_query| E[Embed API]
+  Q[User Query] -->|embed with<br/>search_query| E[Embed API]
   E -->|query vector| VDB[(Vector Database)]
   VDB -->|top-k candidates| RR[Rerank API]
-  RR -->|ranked documents\nwith scores| CMD[Command A]
+  RR -->|ranked documents<br/>with scores| CMD[Command A]
   Q -->|original question| CMD
-  CMD -->|grounded answer\nwith citations| A[Response]
+  CMD -->|grounded answer<br/>with citations| A[Response]
 
-  DOCS[Documents] -->|embed with\nsearch_document| E2[Embed API]
+  DOCS[Documents] -->|embed with<br/>search_document| E2[Embed API]
   E2 -->|document vectors| VDB
 ```
 

--- a/next/content/docs/pt-BR/model-providers/deepseek.mdx
+++ b/next/content/docs/pt-BR/model-providers/deepseek.mdx
@@ -51,14 +51,14 @@ Os pesos dos modelos DeepSeek V4 são publicados no Hugging Face sob licenças p
 
 ```mermaid
 flowchart TD
-  U[User / Application] -->|OpenAI-compatible request| API[DeepSeek API\napi.deepseek.com]
-  U -->|self-hosted request| SH[Self-Hosted Inference\nvLLM / Ollama / NIM]
+  U[User / Application] -->|OpenAI-compatible request| API[DeepSeek API<br/>api.deepseek.com]
+  U -->|self-hosted request| SH[Self-Hosted Inference<br/>vLLM / Ollama / NIM]
 
   API -->|general chat + thinking| V4F[DeepSeek V4 Flash]
   API -->|higher quality + thinking| V4P[DeepSeek V4 Pro]
-  SH -->|open weights| HF[Hugging Face\nModel Weights]
+  SH -->|open weights| HF[Hugging Face<br/>Model Weights]
 
-  V4F -->|thinking mode| THINK["reasoning trace\n(chain-of-thought)"]
+  V4F -->|thinking mode| THINK["reasoning trace<br/>(chain-of-thought)"]
   THINK -->|produces| ANS[Final Answer]
   V4F -->|non-thinking mode| ANS
   V4P -->|thinking / non-thinking| ANS

--- a/next/content/docs/pt-BR/model-providers/google-gemini.mdx
+++ b/next/content/docs/pt-BR/model-providers/google-gemini.mdx
@@ -60,21 +60,21 @@ No Vertex AI, o Gemini é acessado por meio do SDK Python `vertexai` (`aiplatfor
 
 ```mermaid
 flowchart LR
-    Dev[Developer / Application] -->|"API key or service account"| GLAPI["Generative Language API\ngenerativelanguage.googleapis.com"]
+    Dev[Developer / Application] -->|"API key or service account"| GLAPI["Generative Language API<br/>generativelanguage.googleapis.com"]
 
-    GLAPI -->|"stable / GA"| Flash[Gemini 2.5 Flash\nlow-latency / high-throughput]
-    GLAPI -->|"stable / GA"| Pro[Gemini 2.5 Pro\nbalanced / production]
-    GLAPI -->|"preview"| Pro31[Gemini 3.1 Pro Preview\nnext-gen]
+    GLAPI -->|"stable / GA"| Flash[Gemini 2.5 Flash<br/>low-latency / high-throughput]
+    GLAPI -->|"stable / GA"| Pro[Gemini 2.5 Pro<br/>balanced / production]
+    GLAPI -->|"preview"| Pro31[Gemini 3.1 Pro Preview<br/>next-gen]
 
-    Dev -->|"upload assets"| FileAPI[File API\nvideo & audio URIs]
+    Dev -->|"upload assets"| FileAPI[File API<br/>video & audio URIs]
     FileAPI -->|"file URI in request"| GLAPI
 
-    GLAPI -->|"search retrieval tool"| GSearch[Google Search\nreal-time grounding]
+    GLAPI -->|"search retrieval tool"| GSearch[Google Search<br/>real-time grounding]
     GSearch -->|"grounded results"| GLAPI
 
-    AIStudio[Google AI Studio\nprototyping] -->|"generates"| GLAPI
-    VertexAI[Vertex AI\nenterprise production] -->|"managed endpoint"| GLAPI
-    VertexAI -->|"fine-tuning pipeline"| FT[Fine-tuned model\ndeployed on Vertex]
+    AIStudio[Google AI Studio<br/>prototyping] -->|"generates"| GLAPI
+    VertexAI[Vertex AI<br/>enterprise production] -->|"managed endpoint"| GLAPI
+    VertexAI -->|"fine-tuning pipeline"| FT[Fine-tuned model<br/>deployed on Vertex]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/model-providers/meta-llama.mdx
+++ b/next/content/docs/pt-BR/model-providers/meta-llama.mdx
@@ -52,26 +52,26 @@ Uma das vantagens mais atraentes dos modelos de pesos abertos é o acesso comple
 
 ```mermaid
 flowchart TD
-    Source["Meta model weights\n(Hugging Face Hub / llama.com)"] -->|"download weights"| Local
+    Source["Meta model weights<br/>(Hugging Face Hub / llama.com)"] -->|"download weights"| Local
 
     subgraph Local["Local / Self-hosted inference"]
         direction LR
-        TF["Hugging Face Transformers\n(GPU server)"]
-        LCPP["llama.cpp\n(Scout: single H100 INT4)"]
-        vLLM["vLLM\n(production serving, OpenAI-compatible API)"]
+        TF["Hugging Face Transformers<br/>(GPU server)"]
+        LCPP["llama.cpp<br/>(Scout: single H100 INT4)"]
+        vLLM["vLLM<br/>(production serving, OpenAI-compatible API)"]
     end
 
-    Source -->|"weights available for fine-tuning"| FT["Fine-tuning\n(LoRA / QLoRA / SFT)"]
+    Source -->|"weights available for fine-tuning"| FT["Fine-tuning<br/>(LoRA / QLoRA / SFT)"]
     FT -->|"merged or adapter weights"| Local
 
     Source -->|"hosted by provider"| Providers
 
     subgraph Providers["Third-party API providers"]
         direction LR
-        Together["Together AI\n(Llama 4, competitive pricing)"]
-        Groq["Groq\n(LPU hardware, ultra-low latency)"]
-        Fireworks["Fireworks AI\n(serverless, fine-tuned models)"]
-        LlamaAPI["Llama API\n(first-party, llama.com)"]
+        Together["Together AI<br/>(Llama 4, competitive pricing)"]
+        Groq["Groq<br/>(LPU hardware, ultra-low latency)"]
+        Fireworks["Fireworks AI<br/>(serverless, fine-tuned models)"]
+        LlamaAPI["Llama API<br/>(first-party, llama.com)"]
     end
 
     Local -->|"inference request"| App["Your Application"]

--- a/next/content/docs/pt-BR/model-providers/mistral.mdx
+++ b/next/content/docs/pt-BR/model-providers/mistral.mdx
@@ -50,21 +50,21 @@ La Plateforme fornece um endpoint de embedding de texto (`/v1/embeddings`) alime
 
 ```mermaid
 flowchart LR
-    Dev["Developer / Application"] -->|"Bearer token"| API["La Plateforme\napi.mistral.ai (EU hosted)"]
+    Dev["Developer / Application"] -->|"Bearer token"| API["La Plateforme<br/>api.mistral.ai (EU hosted)"]
 
-    API -->|"routes to model"| Large["Mistral Large 3\nopen-weight MoE flagship"]
-    API -->|"routes to model"| Medium["Mistral Medium 3.5\ndense, 128B"]
-    API -->|"routes to model"| Devstral["Devstral 2\ncode generation, 123B"]
-    API -->|"routes to model"| Small["Mistral Small 4\ncost-efficient"]
-    API -->|"embedding endpoint"| Embed["Mistral Embed\n1024-dim multilingual vectors"]
+    API -->|"routes to model"| Large["Mistral Large 3<br/>open-weight MoE flagship"]
+    API -->|"routes to model"| Medium["Mistral Medium 3.5<br/>dense, 128B"]
+    API -->|"routes to model"| Devstral["Devstral 2<br/>code generation, 123B"]
+    API -->|"routes to model"| Small["Mistral Small 4<br/>cost-efficient"]
+    API -->|"embedding endpoint"| Embed["Mistral Embed<br/>1024-dim multilingual vectors"]
 
-    HF["Hugging Face Hub\nopen weights"] -->|"download weights"| SelfHost
+    HF["Hugging Face Hub<br/>open weights"] -->|"download weights"| SelfHost
 
     subgraph SelfHost["Self-hosted inference"]
         direction LR
-        vLLM["vLLM\n(OpenAI-compatible server)"]
-        TF["Transformers\n(research / fine-tuning)"]
-        LCPP["llama.cpp\n(CPU / consumer GPU, GGUF)"]
+        vLLM["vLLM<br/>(OpenAI-compatible server)"]
+        TF["Transformers<br/>(research / fine-tuning)"]
+        LCPP["llama.cpp<br/>(CPU / consumer GPU, GGUF)"]
     end
 
     SelfHost -->|"inference response"| App["Your Application"]

--- a/next/content/docs/pt-BR/model-providers/openai.mdx
+++ b/next/content/docs/pt-BR/model-providers/openai.mdx
@@ -30,7 +30,7 @@ GPT-5.4 e GPT-5.5 suportam cinco modos de raciocínio — `none`, `low`, `medium
 ```mermaid
 flowchart LR
   Client[Client app] -->|POST messages array| ChatAPI[/v1/chat/completions]
-  ChatAPI -->|model routing| Selector{Model\nselector}
+  ChatAPI -->|model routing| Selector{Model<br/>selector}
   Selector -->|flagship| GPT55[GPT-5.5]
   Selector -->|balanced| GPT54[GPT-5.4]
   Selector -->|cost-optimized| Mini[GPT-5.4 mini]
@@ -50,7 +50,7 @@ GPT-5.4 e GPT-5.5 também suportam ferramentas integradas: busca na web, busca e
 flowchart LR
   User[User query] --> LLM[GPT-5.4]
   LLM -->|decides to call tool| ToolCall[tool_calls JSON]
-  ToolCall -->|your code executes| ExtFn[External function\nor API]
+  ToolCall -->|your code executes| ExtFn[External function<br/>or API]
   ExtFn -->|result as tool message| LLM
   LLM -->|final answer| User
 ```

--- a/next/content/docs/pt-BR/model-routing/index.mdx
+++ b/next/content/docs/pt-BR/model-routing/index.mdx
@@ -18,12 +18,12 @@ O roteamento é distinto da cascata (que sempre começa no nível mais barato e 
 
 ```mermaid
 flowchart LR
-  Request[Consulta] --> SemCache\{Cache semântico\nacerto?\}
-  SemCache -->|Sim| CacheHit[Resposta em cache\n0 custo de modelo]
+  Request[Consulta] --> SemCache\{Cache semântico<br/>acerto?\}
+  SemCache -->|Sim| CacheHit[Resposta em cache<br/>0 custo de modelo]
   SemCache -->|Não| Router[Roteador de modelos]
-  Router -->|simples| SmallModel[Modelo pequeno\nex.: Gemini Flash / Haiku]
-  Router -->|médio| MidModel[Modelo intermediário\nex.: GPT-4o / Sonnet]
-  Router -->|complexo| LargeModel[Modelo grande\nex.: o3 / Opus]
+  Router -->|simples| SmallModel[Modelo pequeno<br/>ex.: Gemini Flash / Haiku]
+  Router -->|médio| MidModel[Modelo intermediário<br/>ex.: GPT-4o / Sonnet]
+  Router -->|complexo| LargeModel[Modelo grande<br/>ex.: o3 / Opus]
   SmallModel --> Cache[Armazenar no cache semântico]
   MidModel --> Cache
   LargeModel --> Cache

--- a/next/content/docs/pt-BR/neural-networks/cnn.mdx
+++ b/next/content/docs/pt-BR/neural-networks/cnn.mdx
@@ -17,11 +17,11 @@ As CNNs dominam tarefas de [visão computacional](/docs/cv): classificação de 
 
 ```mermaid
 flowchart LR
-  Input["Imagem de entrada\n(H × W × C)"] -->|"convolução + ReLU"| Conv1["Mapas de features\nCamada Conv 1"]
+  Input["Imagem de entrada<br/>(H × W × C)"] -->|"convolução + ReLU"| Conv1["Mapas de features<br/>Camada Conv 1"]
   Conv1 -->|"max pooling"| Pool1["Features reduzidas"]
   Pool1 -->|"conv + ReLU + pool"| ConvN["Camadas Conv mais profundas"]
   ConvN -->|"aplanar"| Flat["Vetor de features"]
-  Flat -->|"camadas densas"| Output["Saída\n(classe / bbox / máscara)"]
+  Flat -->|"camadas densas"| Output["Saída<br/>(classe / bbox / máscara)"]
 ```
 
 ### Camada convolucional

--- a/next/content/docs/pt-BR/neural-networks/index.mdx
+++ b/next/content/docs/pt-BR/neural-networks/index.mdx
@@ -17,8 +17,8 @@ O aprendizado acontece via **backpropagation** combinado com **descida de gradie
 
 ```mermaid
 flowchart LR
-  Input["Camada de entrada\n(dados brutos)"] -->|"pesos × entradas + bias"| Hidden["Camadas ocultas\n(f de ativação)"]
-  Hidden -->|"representações aprendidas"| Output["Camada de saída\n(previsão)"]
+  Input["Camada de entrada<br/>(dados brutos)"] -->|"pesos × entradas + bias"| Hidden["Camadas ocultas<br/>(f de ativação)"]
+  Hidden -->|"representações aprendidas"| Output["Camada de saída<br/>(previsão)"]
   Output -->|"comparar com rótulo"| Loss["Função de perda"]
   Loss -->|"backpropagation"| Hidden
   Hidden -->|"atualizar pesos"| Hidden

--- a/next/content/docs/pt-BR/neural-networks/rnn.mdx
+++ b/next/content/docs/pt-BR/neural-networks/rnn.mdx
@@ -17,12 +17,12 @@ A ideia central: uma RNN processa uma sequência passo a passo, carregando infor
 
 ```mermaid
 flowchart LR
-  X1["x₁"] --> RNN1["Célula RNN\n(estado h₁)"]
-  X2["x₂"] --> RNN2["Célula RNN\n(estado h₂)"]
-  X3["x₃"] --> RNN3["Célula RNN\n(estado h₃)"]
+  X1["x₁"] --> RNN1["Célula RNN<br/>(estado h₁)"]
+  X2["x₂"] --> RNN2["Célula RNN<br/>(estado h₂)"]
+  X3["x₃"] --> RNN3["Célula RNN<br/>(estado h₃)"]
   RNN1 -->|"h₁"| RNN2
   RNN2 -->|"h₂"| RNN3
-  RNN3 -->|"h₃"| Output["Saída\n(previsão)"]
+  RNN3 -->|"h₃"| Output["Saída<br/>(previsão)"]
 ```
 
 ### Passo recorrente

--- a/next/content/docs/pt-BR/observability/cost-attribution.mdx
+++ b/next/content/docs/pt-BR/observability/cost-attribution.mdx
@@ -26,11 +26,11 @@ Esses atributos, combinados com tags de dimensão personalizadas (ID do usuário
 
 ```mermaid
 flowchart LR
-  Request[Requisição do usuário] -->|marcada com user_id + feature| Span[Span OTel\ngen_ai.usage.input_tokens\ngen_ai.usage.output_tokens]
+  Request[Requisição do usuário] -->|marcada com user_id + feature| Span[Span OTel<br/>gen_ai.usage.input_tokens<br/>gen_ai.usage.output_tokens]
   Span -->|exporta| Backend[Backend de observabilidade]
   Backend -->|token × consulta de preço| CostEngine[Cálculo de custo]
-  CostEngine --> Dashboard[Dashboard de custo\npor usuário · equipe · modelo · funcionalidade]
-  Dashboard --> Alerts[Alertas de orçamento\nlimiar de $ / dia]
+  CostEngine --> Dashboard[Dashboard de custo<br/>por usuário · equipe · modelo · funcionalidade]
+  Dashboard --> Alerts[Alertas de orçamento<br/>limiar de $ / dia]
 ```
 
 No momento da instrumentação, atributos de span personalizados marcam cada chamada LLM com dimensões de negócio (`user.id`, `team.name`, `feature.name`, `experiment.id`). O backend de observabilidade multiplica as contagens de tokens pela tabela de preços por token do provedor (atualizada periodicamente) para calcular o custo em reais/dólares. Dashboards agregados e alertas disparam quando o gasto por usuário ou por funcionalidade excede os limiares configurados.

--- a/next/content/docs/pt-BR/observability/index.mdx
+++ b/next/content/docs/pt-BR/observability/index.mdx
@@ -24,8 +24,8 @@ flowchart TD
   App -->|chamada LLM| LLMProvider[API do provedor LLM]
   App -->|chamada de ferramenta| Tool[Ferramenta externa]
   App -->|query vetorial| VectorDB[Vector store]
-  Collector -->|OTLP| Backend[Backend de observabilidade\nLangfuse / Datadog / Grafana]
-  Backend --> Dashboard[Dashboards\nTraces · Custo · Latência · Qualidade]
+  Collector -->|OTLP| Backend[Backend de observabilidade<br/>Langfuse / Datadog / Grafana]
+  Backend --> Dashboard[Dashboards<br/>Traces · Custo · Latência · Qualidade]
 ```
 
 Cada operação lógica — uma chamada LLM, uma etapa de recuperação, uma invocação de ferramenta — é envolvida em um **span OTel**. Spans carregam timestamps de início/fim, status e atributos. Spans aninhados formam uma **árvore de trace** que representa o caminho completo de execução de uma única requisição. Backends ingerem traces via OTLP (HTTP ou gRPC) e os renderizam como diagramas de cascata, permitindo análise de causa raiz quando uma resposta é lenta ou incorreta.

--- a/next/content/docs/pt-BR/observability/langfuse.mdx
+++ b/next/content/docs/pt-BR/observability/langfuse.mdx
@@ -26,7 +26,7 @@ Principais capacidades:
 flowchart LR
   App[Aplicação LLM] -->|SDK ou OTLP| Langfuse[Servidor Langfuse]
   Langfuse -->|armazena| DB[(PostgreSQL + ClickHouse)]
-  DB --> UI[Dashboard web\nTraces · Prompts · Pontuações]
+  DB --> UI[Dashboard web<br/>Traces · Prompts · Pontuações]
   UI --> Annotators[Anotadores humanos]
   UI --> Evals[Jobs de eval automatizados]
   Langfuse -->|exporta| Analytics[Relatórios de custo / qualidade]

--- a/next/content/docs/pt-BR/observability/tracing.mdx
+++ b/next/content/docs/pt-BR/observability/tracing.mdx
@@ -32,10 +32,10 @@ Cada span OTel possui:
 
 ```mermaid
 flowchart TD
-  UserSpan[Span: handle_user_request\ntrace_id=abc123] -->|filho| RetSpan[Span: vector_search\nlatency=42ms, results=4]
-  UserSpan -->|filho| LLMSpan[Span: gen_ai.chat\nmodel=gpt-4o, tokens=1240]
-  LLMSpan -->|filho| ToolSpan[Span: tool_call::get_weather\nlatency=210ms]
-  UserSpan -->|filho| GuardSpan[Span: guardrail_check\nresult=pass]
+  UserSpan[Span: handle_user_request<br/>trace_id=abc123] -->|filho| RetSpan[Span: vector_search<br/>latency=42ms, results=4]
+  UserSpan -->|filho| LLMSpan[Span: gen_ai.chat<br/>model=gpt-4o, tokens=1240]
+  LLMSpan -->|filho| ToolSpan[Span: tool_call::get_weather<br/>latency=210ms]
+  UserSpan -->|filho| GuardSpan[Span: guardrail_check<br/>result=pass]
 ```
 
 O SDK do OTel, bibliotecas de instrumentação (opentelemetry-instrumentation-openai, opentelemetry-instrumentation-langchain) ou criação manual de spans propagam o `trace_id` por todas as chamadas aninhadas. O OTel Collector recebe spans, aplica amostragem e batching, e os encaminha via OTLP para um backend de observabilidade.

--- a/next/content/docs/pt-BR/prompt-engineering/max-tokens-stop-sequences.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/max-tokens-stop-sequences.mdx
@@ -20,13 +20,13 @@ O **máximo de tokens** define um limite superior estrito sobre quantos tokens o
 ```mermaid
 flowchart TD
   START([Start generation]) --> LOOP[Generate next token]
-  LOOP --> EOS{End-of-sequence\ntoken?}
+  LOOP --> EOS{End-of-sequence<br/>token?}
   EOS -->|yes| DONE([Return output])
-  EOS -->|no| MAXT{Tokens generated\n≥ max_tokens?}
+  EOS -->|no| MAXT{Tokens generated<br/>≥ max_tokens?}
   MAXT -->|yes| DONE
-  MAXT -->|no| STOP{Output ends with\na stop sequence?}
+  MAXT -->|no| STOP{Output ends with<br/>a stop sequence?}
   STOP -->|yes| DONE
-  STOP -->|no| REP[Apply repetition\npenalty to logits]
+  STOP -->|no| REP[Apply repetition<br/>penalty to logits]
   REP --> LOOP
 ```
 

--- a/next/content/docs/pt-BR/prompt-engineering/prompt-formats.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/prompt-formats.mdx
@@ -87,10 +87,10 @@ flowchart TD
   Raw[Raw request] --> Role{Durable rule or task?}
   Role -->|durable| Sys[system / developer / system_instruction]
   Role -->|task + data| User[user message]
-  User --> Delim[Wrap data in delimiter\nXML tags / fenced block]
+  User --> Delim[Wrap data in delimiter<br/>XML tags / fenced block]
   Sys --> Model[LLM]
   Delim --> Model
-  Model --> Out[Output contract\nschema / tags / prefill]
+  Model --> Out[Output contract<br/>schema / tags / prefill]
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/prompt-engineering/self-consistency.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/self-consistency.mdx
@@ -17,13 +17,13 @@ A intuição é que processos de raciocínio corretos tendem a convergir para a 
 
 ```mermaid
 flowchart TD
-  Q[Question + CoT prompt] --> S1[Sample path 1\nhigh temperature]
-  Q --> S2[Sample path 2\nhigh temperature]
-  Q --> SN[Sample path N\nhigh temperature]
+  Q[Question + CoT prompt] --> S1[Sample path 1<br/>high temperature]
+  Q --> S2[Sample path 2<br/>high temperature]
+  Q --> SN[Sample path N<br/>high temperature]
   S1 --> A1[Answer 1]
   S2 --> A2[Answer 2]
   SN --> AN[Answer N]
-  A1 --> VOTE[Majority vote\nover answers]
+  A1 --> VOTE[Majority vote<br/>over answers]
   A2 --> VOTE
   AN --> VOTE
   VOTE --> FINAL[Final answer]

--- a/next/content/docs/pt-BR/prompt-engineering/self-evaluation-calibration.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/self-evaluation-calibration.mdx
@@ -19,7 +19,7 @@ A autoavaliação assume várias formas. A **autocrítica** pede ao modelo para 
 flowchart TD
   Q[Input query] --> GEN[Generate initial response]
   GEN --> SELF[Self-evaluate: critique + confidence]
-  SELF --> CONF{Confidence\nhigh?}
+  SELF --> CONF{Confidence<br/>high?}
   CONF -->|yes| OUT[Return response]
   CONF -->|no| REFINE[Refine based on critique]
   REFINE --> SELF

--- a/next/content/docs/pt-BR/prompt-engineering/step-back-prompting.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/step-back-prompting.mdx
@@ -17,10 +17,10 @@ Por exemplo, em vez de perguntar diretamente "Qual é a temperatura do corpo em 
 
 ```mermaid
 flowchart LR
-  Q[Specific question] --> ABSTRACT[Step-back: ask for\nhigh-level concept/principle]
-  ABSTRACT --> CONCEPT[LLM generates\nabstract context]
+  Q[Specific question] --> ABSTRACT[Step-back: ask for<br/>high-level concept/principle]
+  ABSTRACT --> CONCEPT[LLM generates<br/>abstract context]
   Q --> REASON
-  CONCEPT --> REASON[LLM reasons with\noriginal Q + abstract context]
+  CONCEPT --> REASON[LLM reasons with<br/>original Q + abstract context]
   REASON --> ANS[Final answer]
 ```
 

--- a/next/content/docs/pt-BR/prompt-engineering/structured-outputs.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/structured-outputs.mdx
@@ -20,9 +20,9 @@ flowchart TD
   PROMPT[Prompt with schema/format instruction] --> LLM[LLM]
   LLM --> STRATEGY{Output strategy}
   STRATEGY -->|instruction only| RAW[Raw text — parse manually]
-  STRATEGY -->|JSON mode| JRAW[Guaranteed valid JSON\n— parse with json.loads]
-  STRATEGY -->|tool/function call| SCHEMA[Schema-validated JSON\n— typed object]
-  STRATEGY -->|Instructor/Outlines| PYDANTIC[Pydantic model instance\n— fully validated]
+  STRATEGY -->|JSON mode| JRAW[Guaranteed valid JSON<br/>— parse with json.loads]
+  STRATEGY -->|tool/function call| SCHEMA[Schema-validated JSON<br/>— typed object]
+  STRATEGY -->|Instructor/Outlines| PYDANTIC[Pydantic model instance<br/>— fully validated]
   RAW --> PARSE[Parse + validate]
   JRAW --> PARSE
   SCHEMA --> PARSE

--- a/next/content/docs/pt-BR/prompt-engineering/system-role-contextual-prompting.mdx
+++ b/next/content/docs/pt-BR/prompt-engineering/system-role-contextual-prompting.mdx
@@ -21,11 +21,11 @@ O **prompting contextual** injeta informações de fundo relevantes — trechos 
 
 ```mermaid
 flowchart LR
-  SYS[System prompt\n— rules, persona, format] -->|prefixes conversation| LLM
-  ROLE[Role assignment\n— expertise, style] -->|part of system| LLM
-  CTX[Injected context\n— docs, facts, history] -->|grounding| LLM
+  SYS[System prompt<br/>— rules, persona, format] -->|prefixes conversation| LLM
+  ROLE[Role assignment<br/>— expertise, style] -->|part of system| LLM
+  CTX[Injected context<br/>— docs, facts, history] -->|grounding| LLM
   USER[User message] -->|task input| LLM
-  LLM --> OUT[Response shaped by\nall three inputs]
+  LLM --> OUT[Response shaped by<br/>all three inputs]
 ```
 
 ### Prompts de sistema

--- a/next/content/docs/pt-BR/prompt-security/guardrails.mdx
+++ b/next/content/docs/pt-BR/prompt-security/guardrails.mdx
@@ -22,14 +22,14 @@ Uma arquitetura completa de guardrail impõe quatro categorias de controle:
 
 ```mermaid
 flowchart TD
-  Input[Entrada do usuário] --> PIIScan[Scanner de PII\ndetectar nomes, e-mails, telefone, etc.]
-  PIIScan -->|anonimizar| InjectionDetect[Detector de injeção\nclassificador / correspondência de padrão]
-  InjectionDetect -->|seguro| TopicGate[Portão de tópico / política\nlista de tópicos permitidos]
+  Input[Entrada do usuário] --> PIIScan[Scanner de PII<br/>detectar nomes, e-mails, telefone, etc.]
+  PIIScan -->|anonimizar| InjectionDetect[Detector de injeção<br/>classificador / correspondência de padrão]
+  InjectionDetect -->|seguro| TopicGate[Portão de tópico / política<br/>lista de tópicos permitidos]
   InjectionDetect -->|bloqueado| RejectIn[Rejeitar entrada]
   TopicGate -->|permitido| LLM[Geração LLM]
   TopicGate -->|fora do tópico| Deflect[Resposta de desvio]
   LLM --> ToxScan[Classificador de toxicidade / dano]
-  ToxScan -->|seguro| PIIOut[Scanner de PII na saída\nredigir antes de enviar]
+  ToxScan -->|seguro| PIIOut[Scanner de PII na saída<br/>redigir antes de enviar]
   ToxScan -->|inseguro| Fallback[Fallback / resposta segura]
   PIIOut --> User[Resposta ao usuário]
 ```

--- a/next/content/docs/pt-BR/prompt-security/index.mdx
+++ b/next/content/docs/pt-BR/prompt-security/index.mdx
@@ -25,10 +25,10 @@ Esta seção aborda:
 
 ```mermaid
 flowchart LR
-  UserInput[Entrada do usuário] --> InputGuard[Guardrail de entrada\ndetectar injeção / varredura PII / portão de tópico]
+  UserInput[Entrada do usuário] --> InputGuard[Guardrail de entrada<br/>detectar injeção / varredura PII / portão de tópico]
   InputGuard -->|seguro| LLM[LLM]
   InputGuard -->|bloqueado| Reject[Resposta de rejeição]
-  LLM --> OutputGuard[Guardrail de saída\ntoxicidade / PII / alucinação / política]
+  LLM --> OutputGuard[Guardrail de saída<br/>toxicidade / PII / alucinação / política]
   OutputGuard -->|seguro| Response[Resposta ao usuário]
   OutputGuard -->|bloqueado| Fallback[Resposta de fallback / redigida]
 ```

--- a/next/content/docs/pt-BR/prompt-security/prompt-injection.mdx
+++ b/next/content/docs/pt-BR/prompt-security/prompt-injection.mdx
@@ -19,16 +19,16 @@ Ao contrário de injeção SQL ou buffer overflows, a injeção de prompt explor
 
 ```mermaid
 flowchart TD
-  Attacker[Atacante] -->|embute texto malicioso| Vector[Vetor de injeção\nex.: documento / entrada do usuário / resultado de ferramenta]
-  Vector --> Prompt[Prompt combinado\nsistema + recuperação + usuário]
+  Attacker[Atacante] -->|embute texto malicioso| Vector[Vetor de injeção<br/>ex.: documento / entrada do usuário / resultado de ferramenta]
+  Vector --> Prompt[Prompt combinado<br/>sistema + recuperação + usuário]
   Prompt --> LLM[LLM processa tokens]
-  LLM -->|injeção bem-sucedida| Hijack[Substituir intenção\nexfiltrar dados / contornar política]
+  LLM -->|injeção bem-sucedida| Hijack[Substituir intenção<br/>exfiltrar dados / contornar política]
   LLM -->|injeção bloqueada| Safe[Resposta normal]
 
-  Defense[Defesas] --> InputClassifier[Classificador de entrada\ndetectar padrões de injeção]
-  Defense --> Boundary[Marcadores de limite\ntags XML / delimitadores]
-  Defense --> PrivilegeCtrl[Separação de privilégios\nzona de conteúdo não confiável]
-  Defense --> ToolGuard[Lista de permissão de ferramentas\nexecução sandboxada]
+  Defense[Defesas] --> InputClassifier[Classificador de entrada<br/>detectar padrões de injeção]
+  Defense --> Boundary[Marcadores de limite<br/>tags XML / delimitadores]
+  Defense --> PrivilegeCtrl[Separação de privilégios<br/>zona de conteúdo não confiável]
+  Defense --> ToolGuard[Lista de permissão de ferramentas<br/>execução sandboxada]
 ```
 
 ## Taxonomia de ataques

--- a/next/content/docs/pt-BR/rag/agentic-rag.mdx
+++ b/next/content/docs/pt-BR/rag/agentic-rag.mdx
@@ -29,14 +29,14 @@ Benchmarks de pesquisa consistentemente mostram que o RAG agêntico supera pipel
 
 ```mermaid
 flowchart TD
-  Q[User question] --> Plan[Agent: decompose into sub-questions\nand plan retrieval strategy]
-  Plan --> Retrieve[Retrieve evidence\nfrom one or more tools]
-  Retrieve --> Grade[Agent: grade retrieved docs\nfor relevance and quality]
+  Q[User question] --> Plan[Agent: decompose into sub-questions<br/>and plan retrieval strategy]
+  Plan --> Retrieve[Retrieve evidence<br/>from one or more tools]
+  Retrieve --> Grade[Agent: grade retrieved docs<br/>for relevance and quality]
   Grade --> Sufficient{Evidence sufficient?}
-  Sufficient -->|No| Rewrite[Rewrite query\nor choose different tool]
+  Sufficient -->|No| Rewrite[Rewrite query<br/>or choose different tool]
   Rewrite --> Retrieve
   Sufficient -->|Yes| Compose[Compose answer from evidence]
-  Compose --> Reflect[Agent: self-critique answer\nfor completeness and accuracy]
+  Compose --> Reflect[Agent: self-critique answer<br/>for completeness and accuracy]
   Reflect --> Done{Satisfactory?}
   Done -->|No — revise| Retrieve
   Done -->|Yes| Answer[Final answer + citations]

--- a/next/content/docs/pt-BR/rag/graphrag.mdx
+++ b/next/content/docs/pt-BR/rag/graphrag.mdx
@@ -31,11 +31,11 @@ A fase de indexação offline é o passo mais distintivo do GraphRAG e seu princ
 ```mermaid
 flowchart TD
   Docs[Raw documents] --> Chunk[Text chunking]
-  Chunk --> Extract[LLM entity & relationship extraction\nper chunk]
-  Extract --> Graph[Knowledge graph\nentities + relationships + claims]
-  Graph --> Community[Community detection\nLeiden algorithm]
-  Community --> Summarize[LLM community summary generation\nper community level]
-  Summarize --> Index[Graph index + vector embeddings\nstored in parquet / vector DB]
+  Chunk --> Extract[LLM entity & relationship extraction<br/>per chunk]
+  Extract --> Graph[Knowledge graph<br/>entities + relationships + claims]
+  Graph --> Community[Community detection<br/>Leiden algorithm]
+  Community --> Summarize[LLM community summary generation<br/>per community level]
+  Summarize --> Index[Graph index + vector embeddings<br/>stored in parquet / vector DB]
 ```
 
 1. **Chunking** — Documentos são divididos em unidades de texto (padrão ~300 tokens com sobreposição).
@@ -50,8 +50,8 @@ flowchart TD
 ```mermaid
 flowchart LR
   Q[User query] --> Route{Query type}
-  Route -->|Global: themes / overview| GS[Global search\nmap-reduce over community summaries]
-  Route -->|Local: specific entity| LS[Local search\ngraph traversal from entity nodes]
+  Route -->|Global: themes / overview| GS[Global search<br/>map-reduce over community summaries]
+  Route -->|Local: specific entity| LS[Local search<br/>graph traversal from entity nodes]
   GS --> LLM[LLM synthesizes answer]
   LS --> LLM
   LLM --> Answer[Response with citations]

--- a/next/content/docs/pt-BR/rag/index.mdx
+++ b/next/content/docs/pt-BR/rag/index.mdx
@@ -25,7 +25,7 @@ flowchart LR
   CH -->|encode| EM[Embedding Model]
   EM -->|store| VDB[(Vector Database)]
 
-  CH -.->|strategy: fixed-size,\nsemantic, recursive| CH
+  CH -.->|strategy: fixed-size,<br/>semantic, recursive| CH
 ```
 
 ### Recuperação (no momento da consulta)

--- a/next/content/docs/pt-BR/structured-generation/constrained-decoding.mdx
+++ b/next/content/docs/pt-BR/structured-generation/constrained-decoding.mdx
@@ -22,7 +22,7 @@ Duas classes de autômatos são usadas:
 
 ```mermaid
 flowchart LR
-  Schema[JSON Schema] -->|compilar uma vez| Automaton[Autômato de gramática\nFSM ou pilha]
+  Schema[JSON Schema] -->|compilar uma vez| Automaton[Autômato de gramática<br/>FSM ou pilha]
   Prompt[Prompt + saída parcial] -->|estado atual de parse| Automaton
   Automaton -->|conjunto de próximos tokens válidos| Mask[Máscara de tokens]
   Logits[Logits brutos do LLM] -->|aplicar máscara -inf| Masked[Logits mascarados]

--- a/next/content/docs/pt-BR/structured-generation/instructor-and-json-mode.mdx
+++ b/next/content/docs/pt-BR/structured-generation/instructor-and-json-mode.mdx
@@ -23,7 +23,7 @@ A escolha prática:
 
 ```mermaid
 flowchart LR
-  PydanticModel[Definição de modelo\nPydantic] -->|patch| InstructorClient[Cliente com patch do Instructor]
+  PydanticModel[Definição de modelo<br/>Pydantic] -->|patch| InstructorClient[Cliente com patch do Instructor]
   UserPrompt[Prompt do usuário] --> InstructorClient
   InstructorClient -->|tool call ou prompt JSON| LLMProvider[API do provedor LLM]
   LLMProvider -->|string JSON bruta| InstructorClient

--- a/next/content/docs/pt-BR/synthetic-data/generation-methods.mdx
+++ b/next/content/docs/pt-BR/synthetic-data/generation-methods.mdx
@@ -22,16 +22,16 @@ O campo pode ser organizado em quatro famílias:
 
 ```mermaid
 flowchart TD
-  Seed[Tarefas semente\n~175 exemplos humanos] --> SelfInstr[Self-Instruct\nmodelo gera novas tarefas]
+  Seed[Tarefas semente<br/>~175 exemplos humanos] --> SelfInstr[Self-Instruct<br/>modelo gera novas tarefas]
   SelfInstr -->|filtrar| SIData[Conjunto de dados Self-Instruct]
 
-  Teacher[Modelo professor\nGPT-4o / Claude Opus] --> Distil[Destilação\nprofessor anota entradas]
+  Teacher[Modelo professor<br/>GPT-4o / Claude Opus] --> Distil[Destilação<br/>professor anota entradas]
   Distil -->|respostas do professor| DistilData[Conjunto de dados de destilação]
 
-  Base[Instruções base] --> Evol[Evol-Instruct\nreescrever para adicionar complexidade]
+  Base[Instruções base] --> Evol[Evol-Instruct<br/>reescrever para adicionar complexidade]
   Evol -->|variantes mais difíceis| EvolData[Conjunto de dados evoluído]
 
-  Personas[Biblioteca de personas\n1M+ personas] --> Magpie[Magpie / amostragem de personas\nsimulação multi-turno de usuário]
+  Personas[Biblioteca de personas<br/>1M+ personas] --> Magpie[Magpie / amostragem de personas<br/>simulação multi-turno de usuário]
   Magpie -->|pares multi-turno| PersonaData[Conjunto de dados de persona]
 
   SIData --> Combine[Combinar + deduplicar]

--- a/next/content/docs/pt-BR/synthetic-data/index.mdx
+++ b/next/content/docs/pt-BR/synthetic-data/index.mdx
@@ -27,10 +27,10 @@ Esta seção aborda:
 
 ```mermaid
 flowchart LR
-  Seeds[Tarefas / prompts semente\npoucos exemplos reais] --> Generator[Modelo gerador\nGPT-4o / Claude / Llama]
-  Generator -->|pares sintéticos brutos| Filter[Filtro de qualidade\njuiz LLM + dedup]
+  Seeds[Tarefas / prompts semente<br/>poucos exemplos reais] --> Generator[Modelo gerador<br/>GPT-4o / Claude / Llama]
+  Generator -->|pares sintéticos brutos| Filter[Filtro de qualidade<br/>juiz LLM + dedup]
   Filter -->|conjunto de dados limpo| Train[Ajustar fino do modelo estudante]
-  Train -->|saídas do estudante| Verify[Opcional: verificação\nexecução de código, checagem de fatos]
+  Train -->|saídas do estudante| Verify[Opcional: verificação<br/>execução de código, checagem de fatos]
   Verify -->|aprovado| Dataset[Conjunto de treinamento final]
   Verify -->|reprovado| Reject[Descartar]
 ```

--- a/next/content/docs/pt-BR/synthetic-data/quality-filtering.mdx
+++ b/next/content/docs/pt-BR/synthetic-data/quality-filtering.mdx
@@ -18,15 +18,15 @@ A filtragem opera em dois estágios: (1) imediatamente após a geração de cont
 
 ```mermaid
 flowchart TD
-  RawData[Pares sintéticos brutos\ninstrução + resposta] --> Dedup[Deduplicação\nMinHash / limiar ROUGE-L]
-  Dedup --> LengthFilter[Verificação de comprimento / formato\ntokens mín/máx, validade JSON]
-  LengthFilter --> LLMJudge[LLM como juiz\npontuação por rubrica 1-5]
-  LLMJudge -->|pontuação ≥ limiar| RewardModel[Pontuação do modelo de recompensa\nportão secundário opcional]
+  RawData[Pares sintéticos brutos<br/>instrução + resposta] --> Dedup[Deduplicação<br/>MinHash / limiar ROUGE-L]
+  Dedup --> LengthFilter[Verificação de comprimento / formato<br/>tokens mín/máx, validade JSON]
+  LengthFilter --> LLMJudge[LLM como juiz<br/>pontuação por rubrica 1-5]
+  LLMJudge -->|pontuação ≥ limiar| RewardModel[Pontuação do modelo de recompensa<br/>portão secundário opcional]
   LLMJudge -->|pontuação < limiar| Reject1[Descartar]
-  RewardModel -->|aprovado| VerifTask\{Tarefa verificável?\ncódigo / matemática\}
+  RewardModel -->|aprovado| VerifTask\{Tarefa verificável?<br/>código / matemática\}
   RewardModel -->|reprovado| Reject2[Descartar]
-  VerifTask -->|Sim| Execute[Executar / teste unitário\nou verificação simbólica]
-  VerifTask -->|Não| Safety[Classificador de segurança\ntoxicidade, PII, viés]
+  VerifTask -->|Sim| Execute[Executar / teste unitário<br/>ou verificação simbólica]
+  VerifTask -->|Não| Safety[Classificador de segurança<br/>toxicidade, PII, viés]
   Execute -->|aprovado| Safety
   Execute -->|reprovado| Reject3[Descartar]
   Safety -->|aprovado| FinalData[Conjunto de treinamento final]

--- a/next/content/docs/pt-BR/tools/antigravity.mdx
+++ b/next/content/docs/pt-BR/tools/antigravity.mdx
@@ -15,8 +15,8 @@ O editor foi desenvolvido para baixar a fricção entre ideia e código funciona
 
 ```mermaid
 flowchart LR
-  User["Intenção do usuário\n(prompt de linguagem natural)"] -->|"submeter"| Planner["Planejador de agente"]
-  Planner -->|"decompor em etapas"| Tools["Ferramentas: leitura/escrita\nde arquivo, terminal, busca"]
+  User["Intenção do usuário<br/>(prompt de linguagem natural)"] -->|"submeter"| Planner["Planejador de agente"]
+  Planner -->|"decompor em etapas"| Tools["Ferramentas: leitura/escrita<br/>de arquivo, terminal, busca"]
   Tools -->|"resultados"| Verifier["Verificador"]
   Verifier -->|"objetivo atingido?"| Done["Saída / diff"]
   Verifier -->|"não"| Planner

--- a/next/content/docs/pt-BR/tools/kiro.mdx
+++ b/next/content/docs/pt-BR/tools/kiro.mdx
@@ -17,7 +17,7 @@ Kiro também apresenta **hooks de agentes** — gatilhos automáticos que execut
 
 ```mermaid
 flowchart LR
-  Idea["Ideia do usuário"] -->|"colaboração em chat"| Spec["Especificações\n(requisitos + histórias + design)"]
+  Idea["Ideia do usuário"] -->|"colaboração em chat"| Spec["Especificações<br/>(requisitos + histórias + design)"]
   Spec -->|"aprovado"| Agent["Agente Kiro"]
   Agent -->|"implementa"| Code["Base de código"]
   Code -->|"evento: salvar / PR / teste"| Hooks["Hooks de agentes"]

--- a/next/content/docs/pt-BR/tools/llamaindex.mdx
+++ b/next/content/docs/pt-BR/tools/llamaindex.mdx
@@ -19,10 +19,10 @@ O LlamaIndex também suporta [agentes](/docs/agents): motores de consulta podem 
 
 ```mermaid
 flowchart LR
-  Source["Fonte de dados\n(arquivos, APIs, BDs)"] -->|"carregar"| Loader["Carregador de documentos"]
-  Loader -->|"dividir"| Parser["Analisador de nós\n(chunking)"]
+  Source["Fonte de dados<br/>(arquivos, APIs, BDs)"] -->|"carregar"| Loader["Carregador de documentos"]
+  Loader -->|"dividir"| Parser["Analisador de nós<br/>(chunking)"]
   Parser -->|"incorporar"| Embed["Modelo de embedding"]
-  Embed -->|"armazenar"| Index["Índice\n(vetor / palavras-chave / grafo)"]
+  Embed -->|"armazenar"| Index["Índice<br/>(vetor / palavras-chave / grafo)"]
 ```
 
 ### Pipeline de consulta
@@ -31,7 +31,7 @@ flowchart LR
 flowchart LR
   Query["Consulta do usuário"] -->|"incorporar & buscar"| Retriever["Recuperador"]
   Retriever -->|"top-k nós"| Reranker["Reranker (opcional)"]
-  Reranker -->|"contexto ranqueado"| Synth["Sintetizador de respostas\n(LLM)"]
+  Reranker -->|"contexto ranqueado"| Synth["Sintetizador de respostas<br/>(LLM)"]
   Synth -->|"resposta"| Response["Resposta final"]
 ```
 

--- a/next/content/docs/pt-BR/voice-agents/index.mdx
+++ b/next/content/docs/pt-BR/voice-agents/index.mdx
@@ -24,9 +24,9 @@ Principais componentes abordados nesta seção:
 ```mermaid
 flowchart LR
   Mic[Microfone / áudio telefônico] -->|WebRTC / SIP| VAD[VAD — segmentação de fala]
-  VAD -->|segmentos de fala| STT[Modelo ASR\nex.: Deepgram Nova-3]
-  STT -->|transcrição| LLM[LLM\nex.: GPT-4o / Claude]
-  LLM -->|resposta em texto| TTS[Modelo TTS\nex.: ElevenLabs / Deepgram Aura]
+  VAD -->|segmentos de fala| STT[Modelo ASR<br/>ex.: Deepgram Nova-3]
+  STT -->|transcrição| LLM[LLM<br/>ex.: GPT-4o / Claude]
+  LLM -->|resposta em texto| TTS[Modelo TTS<br/>ex.: ElevenLabs / Deepgram Aura]
   TTS -->|stream de áudio| Speaker[Alto-falante / telefonia]
 ```
 

--- a/next/content/docs/pt-BR/voice-agents/realtime-audio.mdx
+++ b/next/content/docs/pt-BR/voice-agents/realtime-audio.mdx
@@ -16,8 +16,8 @@ tags:
 
 ```mermaid
 flowchart LR
-  Client[Navegador / Telefone] -->|WebRTC / SIP| Media[Servidor de mídia\nLiveKit / Daily / Twilio]
-  Media -->|áudio PCM| Agent[Processo do agente\nPython / Node]
+  Client[Navegador / Telefone] -->|WebRTC / SIP| Media[Servidor de mídia<br/>LiveKit / Daily / Twilio]
+  Media -->|áudio PCM| Agent[Processo do agente<br/>Python / Node]
   Agent -->|chamada STT| ASR[API ASR]
   Agent -->|chamada LLM| LLM[API LLM]
   Agent -->|chamada TTS| TTS[API TTS]

--- a/next/content/docs/pt-BR/voice-agents/stt-llm-tts-pipeline.mdx
+++ b/next/content/docs/pt-BR/voice-agents/stt-llm-tts-pipeline.mdx
@@ -18,13 +18,13 @@ A restrição central é um **orçamento de 300 ms**: em 300 ms ou menos de lat�
 
 ```mermaid
 flowchart TD
-  Audio[Stream de áudio bruto] --> VAD[Detecção de Atividade de Voz\nsilero-VAD / Deepgram streaming]
-  VAD -->|sinal de fim de enunciado| STT[ASR\nDeepgram Nova-3 / Whisper v3]
-  STT -->|texto transcrito| Prompt[Construção do prompt\nsistema + histórico + turno do usuário]
-  Prompt --> LLM[LLM — streaming\nGPT-4o / Claude / Gemini]
-  LLM -->|stream de tokens| Splitter[Divisor de sentenças\nprimeiros 8-15 tokens → enviar]
-  Splitter -->|chunk de sentença| TTS[Síntese TTS\nElevenLabs / Deepgram Aura]
-  TTS -->|chunks de áudio| Playback[Reprodução de áudio\nWebRTC / PCM]
+  Audio[Stream de áudio bruto] --> VAD[Detecção de Atividade de Voz<br/>silero-VAD / Deepgram streaming]
+  VAD -->|sinal de fim de enunciado| STT[ASR<br/>Deepgram Nova-3 / Whisper v3]
+  STT -->|texto transcrito| Prompt[Construção do prompt<br/>sistema + histórico + turno do usuário]
+  Prompt --> LLM[LLM — streaming<br/>GPT-4o / Claude / Gemini]
+  LLM -->|stream de tokens| Splitter[Divisor de sentenças<br/>primeiros 8-15 tokens → enviar]
+  Splitter -->|chunk de sentença| TTS[Síntese TTS<br/>ElevenLabs / Deepgram Aura]
+  TTS -->|chunks de áudio| Playback[Reprodução de áudio<br/>WebRTC / PCM]
 ```
 
 ### Estágio 1 — Detecção de Atividade de Voz (VAD)

--- a/redirect/404.html
+++ b/redirect/404.html
@@ -7,10 +7,10 @@
 <title>AI Summary Hub has moved</title>
 <script>
 /* Old GitHub Pages site (Docusaurus, base /ai-summary-hub/) now redirects to
-   the new Fumadocs site on aisummaryhub.dev, preserving the path.
+   the new Fumadocs site on ai-hub.emersonbraun.dev, preserving the path.
    Served as both index.html and 404.html so every deep link is caught. */
 (function () {
-  var NEW_ORIGIN = 'https://aisummaryhub.dev';
+  var NEW_ORIGIN = 'https://ai-hub.emersonbraun.dev';
   var BASE = '/ai-summary-hub';
   // Locales the new site supports. Others (es, fr, de, zh-Hans) fold to EN.
   var KEEP_LOCALES = { 'pt-BR': 1 };
@@ -33,8 +33,8 @@
   window.location.replace(dest);
 })();
 </script>
-<link rel="canonical" href="https://aisummaryhub.dev/">
-<meta http-equiv="refresh" content="3; url=https://aisummaryhub.dev/">
+<link rel="canonical" href="https://ai-hub.emersonbraun.dev/">
+<meta http-equiv="refresh" content="3; url=https://ai-hub.emersonbraun.dev/">
 <style>
   body{font:16px/1.6 system-ui,sans-serif;background:#0a0c10;color:#f5f7fa;
        display:flex;min-height:100vh;margin:0;align-items:center;justify-content:center;text-align:center}
@@ -44,7 +44,7 @@
 <body>
 <main>
   <h1>AI Summary Hub has moved</h1>
-  <p>Redirecting to <a href="https://aisummaryhub.dev/">aisummaryhub.dev</a>…</p>
+  <p>Redirecting to <a href="https://ai-hub.emersonbraun.dev/">ai-hub.emersonbraun.dev</a>…</p>
 </main>
 </body>
 </html>

--- a/redirect/index.html
+++ b/redirect/index.html
@@ -7,10 +7,10 @@
 <title>AI Summary Hub has moved</title>
 <script>
 /* Old GitHub Pages site (Docusaurus, base /ai-summary-hub/) now redirects to
-   the new Fumadocs site on aisummaryhub.dev, preserving the path.
+   the new Fumadocs site on ai-hub.emersonbraun.dev, preserving the path.
    Served as both index.html and 404.html so every deep link is caught. */
 (function () {
-  var NEW_ORIGIN = 'https://aisummaryhub.dev';
+  var NEW_ORIGIN = 'https://ai-hub.emersonbraun.dev';
   var BASE = '/ai-summary-hub';
   // Locales the new site supports. Others (es, fr, de, zh-Hans) fold to EN.
   var KEEP_LOCALES = { 'pt-BR': 1 };
@@ -33,8 +33,8 @@
   window.location.replace(dest);
 })();
 </script>
-<link rel="canonical" href="https://aisummaryhub.dev/">
-<meta http-equiv="refresh" content="3; url=https://aisummaryhub.dev/">
+<link rel="canonical" href="https://ai-hub.emersonbraun.dev/">
+<meta http-equiv="refresh" content="3; url=https://ai-hub.emersonbraun.dev/">
 <style>
   body{font:16px/1.6 system-ui,sans-serif;background:#0a0c10;color:#f5f7fa;
        display:flex;min-height:100vh;margin:0;align-items:center;justify-content:center;text-align:center}
@@ -44,7 +44,7 @@
 <body>
 <main>
   <h1>AI Summary Hub has moved</h1>
-  <p>Redirecting to <a href="https://aisummaryhub.dev/">aisummaryhub.dev</a>…</p>
+  <p>Redirecting to <a href="https://ai-hub.emersonbraun.dev/">ai-hub.emersonbraun.dev</a>…</p>
 </main>
 </body>
 </html>

--- a/src/clientModules/redirectToApp.js
+++ b/src/clientModules/redirectToApp.js
@@ -1,0 +1,41 @@
+/**
+ * Legacy Docusaurus → new app redirect.
+ *
+ * The Docusaurus app is KEPT in the repo for reference/rollback, but the
+ * deployed site only redirects: every path bounces to the new Fumadocs app
+ * at https://ai-hub.emersonbraun.dev, preserving the path and folding
+ * unsupported locales (es/fr/de/zh-Hans) to EN while keeping pt-BR.
+ *
+ * Runs client-side only. Skips localhost so local Docusaurus dev still works.
+ */
+const NEW_ORIGIN = 'https://ai-hub.emersonbraun.dev';
+const BASE = '/ai-summary-hub';
+const KEEP_LOCALES = {'pt-BR': 1};
+const DROP_LOCALES = {es: 1, fr: 1, de: 1, 'zh-Hans': 1};
+
+if (typeof window !== 'undefined') {
+  const host = window.location.hostname;
+  const isLocal =
+    host === 'localhost' || host === '127.0.0.1' || host === '0.0.0.0';
+  if (!isLocal) {
+    let path = window.location.pathname || '/';
+    if (path.indexOf(BASE) === 0) path = path.slice(BASE.length);
+    let dest;
+    if (path === '' || path === '/') {
+      dest = NEW_ORIGIN + '/';
+    } else {
+      const parts = path.split('/').filter(Boolean);
+      if (DROP_LOCALES[parts[0]]) parts.shift();
+      else if (KEEP_LOCALES[parts[0]]) {
+        /* keep pt-BR prefix */
+      }
+      dest =
+        NEW_ORIGIN +
+        '/' +
+        parts.join('/') +
+        window.location.search +
+        window.location.hash;
+    }
+    window.location.replace(dest);
+  }
+}


### PR DESCRIPTION
Mermaid node labels used `\n`, making Mermaid emit an unclosed `<br>` in the rendered SVG → browser XML error "Opening and ending tag mismatch: br line 1 and p" on every doc with a diagram (e.g. /docs/claude-code/claude-md). Replaced `\n`→`<br/>` in all ```mermaid blocks (787 across 193 files). Build green: 404 pages.