### PR TITLE
feat(ecosystem): position Hub as AgentsKit ecosystem learn layer

### DIFF
--- a/next/app/[lang]/(home)/layout.tsx
+++ b/next/app/[lang]/(home)/layout.tsx
@@ -1,7 +1,8 @@
 import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import type { ReactNode } from 'react';
-import { baseOptions } from '@/lib/layout.shared';
+import { getBaseOptions } from '@/lib/layout.shared';
 import { Footer } from '@/components/footer';
+import { FunnelBanner } from '@/components/funnel-banner';
 import type { Locale } from '@/lib/site';
 
 export default async function Layout({
@@ -13,11 +14,13 @@ export default async function Layout({
 }) {
   const { lang } = await params;
   const locale: Locale = lang === 'pt-BR' ? 'pt-BR' : 'en';
+  const baseOptions = await getBaseOptions(locale);
   return (
     <div className="flex min-h-dvh flex-col">
       <HomeLayout {...baseOptions} className="flex-1">
         {children}
       </HomeLayout>
+      <FunnelBanner lang={locale} />
       <Footer lang={locale} />
     </div>
   );

--- a/next/app/[lang]/(home)/page.tsx
+++ b/next/app/[lang]/(home)/page.tsx
@@ -78,40 +78,56 @@ const WHY = {
   ],
 } as const;
 
+const UTM = 'utm_source=aisummaryhub&utm_medium=home&utm_campaign=ecosystem';
+
 const PROJECTS = {
   en: {
-    heading: 'Open-source projects',
-    subtitle: 'Tools from the same author — free and open source.',
+    heading: 'Part of the AgentsKit ecosystem',
+    subtitle: 'Learn the concepts here, then take them to production.',
+    steps: [
+      { k: 'Learn', d: 'Concepts, cited — right here', here: true },
+      { k: 'Build', d: 'Agents in JavaScript with AgentsKit', here: false },
+      { k: 'Ship', d: 'Orchestrate in production with AKOS', here: false },
+    ],
     cards: [
       {
         name: 'AgentsKit',
-        href: 'https://www.agentskit.io/',
-        desc: 'The most complete library for building AI agents. Production-ready framework with memory, tools, multi-agent orchestration, and more.',
-        cta: 'Visit documentation →',
+        badge: 'Build',
+        href: `https://www.agentskit.io?${UTM}`,
+        desc: 'Ship AI agents in JavaScript without gluing 8 libraries together. Chat UI, runtime, tools, memory, RAG, and guardrails in one ecosystem.',
+        cta: 'Start building →',
       },
       {
-        name: 'Skills',
-        href: 'https://github.com/EmersonBraun/skills',
-        desc: 'A curated repository of reusable AI skills for Claude Code and other AI coding assistants. Boost your dev workflow instantly.',
-        cta: 'View on GitHub →',
+        name: 'AKOS',
+        badge: 'Ship',
+        href: `https://akos.agentskit.io?${UTM}`,
+        desc: 'The AgentsKit control plane — orchestration, governance, and observability for running agents in production at scale.',
+        cta: 'Explore AKOS →',
       },
     ],
   },
   'pt-BR': {
-    heading: 'Projetos open source',
-    subtitle: 'Ferramentas do mesmo autor — gratuitas e open source.',
+    heading: 'Parte do ecossistema AgentsKit',
+    subtitle: 'Aprenda os conceitos aqui e leve-os para produção.',
+    steps: [
+      { k: 'Aprenda', d: 'Conceitos, com fontes — aqui', here: true },
+      { k: 'Construa', d: 'Agentes em JavaScript com AgentsKit', here: false },
+      { k: 'Suba', d: 'Orquestre em produção com AKOS', here: false },
+    ],
     cards: [
       {
         name: 'AgentsKit',
-        href: 'https://www.agentskit.io/',
-        desc: 'A biblioteca mais completa para construir agentes de IA. Framework pronto para produção com memória, ferramentas, orquestração multi-agente e mais.',
-        cta: 'Ver documentação →',
+        badge: 'Construa',
+        href: `https://www.agentskit.io?${UTM}`,
+        desc: 'Construa agentes de IA em JavaScript sem colar 8 bibliotecas. Chat UI, runtime, ferramentas, memória, RAG e guardrails em um só ecossistema.',
+        cta: 'Começar a construir →',
       },
       {
-        name: 'Skills',
-        href: 'https://github.com/EmersonBraun/skills',
-        desc: 'Um repositório curado de skills de IA reutilizáveis para Claude Code e outros assistentes de código. Acelere seu fluxo de dev na hora.',
-        cta: 'Ver no GitHub →',
+        name: 'AKOS',
+        badge: 'Suba',
+        href: `https://akos.agentskit.io?${UTM}`,
+        desc: 'O control plane do AgentsKit — orquestração, governança e observabilidade para rodar agentes em produção e em escala.',
+        cta: 'Explorar AKOS →',
       },
     ],
   },
@@ -173,7 +189,7 @@ export default async function HomePage(props: { params: Promise<Params> }) {
                 <span className="h-2.5 w-2.5 rounded-full bg-white/20" />
               </div>
               <code className="block text-white/80">
-                <span style={{ color: 'var(--ash-accent)' }}>$</span> curl
+                <span style={{ color: 'var(--ash-accent-2)' }}>$</span> curl
                 aisummaryhub.dev/docs/agents/index.mdx
                 <br />
                 <span className="text-white/40">
@@ -270,6 +286,40 @@ export default async function HomePage(props: { params: Promise<Params> }) {
             </h2>
             <p className="mt-3 text-fd-muted-foreground">{PROJECTS[lang].subtitle}</p>
           </div>
+
+          {/* Learn → Build → Ship — the ecosystem funnel, "you are here" on Learn */}
+          <ol className="mx-auto mb-10 flex max-w-3xl flex-col items-stretch gap-3 sm:flex-row sm:items-center">
+            {PROJECTS[lang].steps.map((step, i) => (
+              <li key={step.k} className="flex flex-1 items-center gap-3">
+                <div
+                  className={`flex-1 rounded-xl border p-4 ${
+                    step.here
+                      ? 'border-fd-primary bg-fd-primary/5'
+                      : 'border-fd-border bg-fd-card'
+                  }`}
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-xs text-fd-primary">
+                      {String(i + 1).padStart(2, '0')}
+                    </span>
+                    <span className="text-sm font-semibold">{step.k}</span>
+                    {step.here && (
+                      <span className="ml-auto rounded-full bg-fd-primary px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-fd-primary-foreground">
+                        {lang === 'en' ? 'You are here' : 'Você está aqui'}
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1.5 text-xs text-fd-muted-foreground">{step.d}</p>
+                </div>
+                {i < PROJECTS[lang].steps.length - 1 && (
+                  <span className="hidden text-fd-muted-foreground sm:inline" aria-hidden>
+                    →
+                  </span>
+                )}
+              </li>
+            ))}
+          </ol>
+
           <div className="grid gap-5 md:grid-cols-2">
             {PROJECTS[lang].cards.map((p) => (
               <a
@@ -279,7 +329,7 @@ export default async function HomePage(props: { params: Promise<Params> }) {
                 rel="noopener noreferrer"
                 className="ash-banner group flex flex-col rounded-2xl p-8"
               >
-                <span className="ash-badge w-fit">Open Source</span>
+                <span className="ash-badge w-fit">{p.badge}</span>
                 <h3 className="mt-5 text-2xl font-bold">{p.name}</h3>
                 <p className="mt-3 text-sm leading-relaxed text-white/70">{p.desc}</p>
                 <span

--- a/next/app/[lang]/docs/layout.tsx
+++ b/next/app/[lang]/docs/layout.tsx
@@ -1,8 +1,9 @@
 import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import type { ReactNode } from 'react';
-import { baseOptions } from '@/lib/layout.shared';
+import { getBaseOptions } from '@/lib/layout.shared';
 import { source } from '@/lib/source';
 import { Footer } from '@/components/footer';
+import { FunnelBanner } from '@/components/funnel-banner';
 import type { Locale } from '@/lib/site';
 
 export default async function Layout({
@@ -14,11 +15,13 @@ export default async function Layout({
 }) {
   const { lang } = await params;
   const locale: Locale = lang === 'pt-BR' ? 'pt-BR' : 'en';
+  const baseOptions = await getBaseOptions(locale);
   return (
     <div className="flex min-h-dvh flex-col">
       <DocsLayout tree={source.getPageTree(lang)} {...baseOptions}>
         {children}
       </DocsLayout>
+      <FunnelBanner lang={locale} />
       <Footer lang={locale} />
     </div>
   );

--- a/next/app/global.css
+++ b/next/app/global.css
@@ -14,12 +14,24 @@
   min-height: 0 !important;
 }
 
-/* --- Fancy landing (agentskit.io-inspired) --- */
+/* --- Ecosystem palette (AgentsKit / emersonbraun.dev) ---
+   Violet is the shared ecosystem brand color; teal is a secondary accent
+   reserved for micro-details (terminal prompt, gradient tails). Keeping the
+   primary in lockstep with AgentsKit is what makes the three sites read as
+   one family. fd-primary is pinned to the same violet so docs UI (links,
+   cards, focus rings) match the landing. */
 :root {
-  --ash-accent: #00e0c6;
-  --ash-accent-2: #6d5cff;
+  --ash-accent: #6d5cff;
+  --ash-accent-2: #00e0c6;
   --ash-ink: #0a0c10;
   --ash-ink-2: #11141b;
+  --color-fd-primary: #5b4bff;
+  --color-fd-ring: #5b4bff;
+}
+
+.dark {
+  --color-fd-primary: #8b7dff;
+  --color-fd-ring: #8b7dff;
 }
 
 .ash-hero {

--- a/next/app/layout.tsx
+++ b/next/app/layout.tsx
@@ -1,9 +1,11 @@
 import './global.css';
 import { RootProvider } from 'fumadocs-ui/provider/next';
 import Script from 'next/script';
+import { Suspense } from 'react';
 import type { ReactNode } from 'react';
 import type { Metadata } from 'next';
 import { SITE } from '@/lib/site';
+import { PostHogProvider } from '@/components/posthog-provider';
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE.url),
@@ -57,7 +59,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <RootProvider
           theme={{ defaultTheme: 'dark', enableSystem: false }}
         >
-          {children}
+          {/* Suspense required because PostHogProvider uses useSearchParams */}
+          <Suspense>
+            <PostHogProvider>{children}</PostHogProvider>
+          </Suspense>
         </RootProvider>
         <script suppressHydrationWarning>{LANG_PATCH}</script>
         <Script

--- a/next/components/ecosystem-stars.tsx
+++ b/next/components/ecosystem-stars.tsx
@@ -1,0 +1,36 @@
+import { ECOSYSTEM } from '@/lib/ecosystem';
+import type { Locale } from '@/lib/site';
+
+const LABEL: Record<Locale, string> = {
+  en: 'across the ecosystem',
+  'pt-BR': 'no ecossistema',
+};
+
+/**
+ * Header badge showing the summed GitHub stars of the whole AgentsKit
+ * ecosystem. Small numbers individually — together they tell one story.
+ */
+export function EcosystemStars({ stars, lang }: { stars: number; lang: Locale }) {
+  return (
+    <a
+      href={ECOSYSTEM.agentskitGithub}
+      target="_blank"
+      rel="noopener noreferrer"
+      title={`${stars} ${LABEL[lang]}`}
+      className="inline-flex items-center gap-1.5 rounded-full border border-fd-border px-2.5 py-1 text-xs font-medium text-fd-muted-foreground transition-colors hover:border-fd-primary hover:text-fd-primary"
+    >
+      <svg
+        width={13}
+        height={13}
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden
+        className="text-fd-primary"
+      >
+        <path d="M12 2l2.9 6.6 7.1.6-5.4 4.7 1.6 7L12 17.8 5.8 20.9l1.6-7L2 9.2l7.1-.6z" />
+      </svg>
+      <span className="tabular-nums text-fd-foreground">{stars}</span>
+      <span className="hidden sm:inline">{LABEL[lang]}</span>
+    </a>
+  );
+}

--- a/next/components/footer.tsx
+++ b/next/components/footer.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { SITE } from '@/lib/site';
 import type { Locale } from '@/lib/site';
+import { ECOSYSTEM_LINKS } from '@/lib/ecosystem';
 
 const ICON = 20;
 
@@ -48,10 +49,6 @@ const SOCIAL = [
   { label: 'GitHub', href: SITE.github },
 ] as const;
 
-const OSS = [
-  { label: 'AgentsKit', href: 'https://www.agentskit.io/' },
-  { label: 'Skills', href: 'https://github.com/EmersonBraun/skills' },
-] as const;
 
 const COPY = {
   en: {
@@ -60,8 +57,7 @@ const COPY = {
     docs: 'Docs',
     rss: 'RSS feed',
     connect: 'Connect',
-    oss: 'Open Source',
-    ossDesc: { AgentsKit: 'AI agent framework', Skills: 'Reusable AI skills' },
+    oss: 'Ecosystem',
   },
   'pt-BR': {
     builtBy: 'Feito por',
@@ -69,8 +65,7 @@ const COPY = {
     docs: 'Docs',
     rss: 'Feed RSS',
     connect: 'Conectar',
-    oss: 'Open Source',
-    ossDesc: { AgentsKit: 'Framework de agentes de IA', Skills: 'Skills de IA reutilizáveis' },
+    oss: 'Ecossistema',
   },
 } as const;
 
@@ -106,7 +101,7 @@ export function Footer({ lang }: { lang: Locale }) {
         <div>
           <div className="text-sm font-semibold">{copy.oss}</div>
           <ul className="mt-4 space-y-2 text-sm">
-            {OSS.map((o) => (
+            {ECOSYSTEM_LINKS[lang].items.map((o) => (
               <li key={o.label}>
                 <a
                   href={o.href}
@@ -115,9 +110,7 @@ export function Footer({ lang }: { lang: Locale }) {
                   className="text-fd-muted-foreground hover:text-fd-primary"
                 >
                   <span className="font-medium text-fd-foreground">{o.label}</span>
-                  <span className="block text-xs text-fd-muted-foreground">
-                    {copy.ossDesc[o.label as 'AgentsKit' | 'Skills']}
-                  </span>
+                  <span className="block text-xs text-fd-muted-foreground">{o.sub}</span>
                 </a>
               </li>
             ))}

--- a/next/components/funnel-banner.tsx
+++ b/next/components/funnel-banner.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { track } from "@/lib/posthog-client";
+import type { Locale } from "@/lib/site";
+
+const UTM = "utm_source=aisummaryhub&utm_medium=footer&utm_campaign=ecosystem";
+
+const LINKS = {
+  newsletter: `https://emersonbraun.dev/newsletter?${UTM}`,
+  agentskit: `https://www.agentskit.io?${UTM}`,
+} as const;
+
+type LinkTarget = keyof typeof LINKS;
+
+const COPY: Record<Locale, { newsletter: string; agentskit: string; separator: string }> = {
+  en: {
+    newsletter: "Weekly AI insights — Emerson's newsletter",
+    agentskit: "Build agents with AgentsKit",
+    separator: "·",
+  },
+  "pt-BR": {
+    newsletter: "Insights semanais de IA — newsletter do Emerson",
+    agentskit: "Construa agentes com AgentsKit",
+    separator: "·",
+  },
+};
+
+function FunnelLink({
+  href,
+  target,
+  children,
+}: {
+  href: string;
+  target: LinkTarget;
+  children: React.ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onClick={() =>
+        track("funnel_click", {
+          target,
+          utm_source: "aisummaryhub",
+          utm_medium: "footer",
+          utm_campaign: "ecosystem",
+        })
+      }
+      className="inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium text-fd-muted-foreground transition-colors hover:bg-fd-accent hover:text-fd-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * A tasteful top-of-funnel nudge bar rendered once at the bottom of every docs
+ * and home page. Drives newsletter sign-ups and AgentsKit discovery without
+ * being intrusive. Wired via layout — never pasted per-article.
+ */
+export function FunnelBanner({ lang }: { lang: Locale }) {
+  const copy = COPY[lang];
+
+  return (
+    <div className="border-t border-fd-border bg-fd-card/60">
+      <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-center gap-1 px-4 py-3 text-sm text-fd-muted-foreground">
+        {/* Newsletter CTA */}
+        <FunnelLink href={LINKS.newsletter} target="newsletter">
+          {/* Envelope icon */}
+          <svg
+            width={15}
+            height={15}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <rect x="2" y="4" width="20" height="16" rx="2" />
+            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+          </svg>
+          {copy.newsletter}
+        </FunnelLink>
+
+        <span className="select-none text-fd-border" aria-hidden>
+          {copy.separator}
+        </span>
+
+        {/* AgentsKit CTA */}
+        <FunnelLink href={LINKS.agentskit} target="agentskit">
+          {/* Sparkle / agent icon */}
+          <svg
+            width={15}
+            height={15}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M12 2l2.4 7.4H22l-6.2 4.5 2.4 7.4L12 17l-6.2 4.3 2.4-7.4L2 9.4h7.6z" />
+          </svg>
+          {copy.agentskit}
+        </FunnelLink>
+      </div>
+    </div>
+  );
+}

--- a/next/components/posthog-provider.tsx
+++ b/next/components/posthog-provider.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { initPostHog } from "@/lib/posthog-client";
+
+/**
+ * Client component that initialises PostHog once and re-fires a pageview on
+ * every soft navigation. Wrap the app root with this (inside RootProvider).
+ */
+export function PostHogProvider({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // Initialise once on mount.
+  useEffect(() => {
+    initPostHog();
+  }, []);
+
+  // Capture a pageview on each navigation (history_change handles SPA navs, but
+  // an explicit call here is belt-and-suspenders for the initial server-render).
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_KEY && typeof window !== "undefined") {
+      const url =
+        pathname +
+        (searchParams?.toString() ? `?${searchParams.toString()}` : "");
+      import("posthog-js").then(({ default: posthog }) => {
+        posthog.capture("$pageview", { $current_url: window.location.href });
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pathname, searchParams]);
+
+  return <>{children}</>;
+}

--- a/next/lib/ecosystem.ts
+++ b/next/lib/ecosystem.ts
@@ -1,0 +1,133 @@
+import type { Locale } from '@/lib/site';
+
+const UTM = 'utm_source=aisummaryhub&utm_medium=ecosystem&utm_campaign=cohesion';
+
+/**
+ * The AgentsKit ecosystem. AI Summary Hub is the "learn" layer — read the
+ * concepts here, build them with AgentsKit, ship them with AKOS. These links
+ * and the summed star count keep every surface cross-related.
+ */
+export const ECOSYSTEM = {
+  author: 'Emerson Braun',
+  authorUrl: `https://emersonbraun.dev?${UTM}`,
+  agentskit: `https://www.agentskit.io?${UTM}`,
+  agentskitGithub: 'https://github.com/AgentsKit-io/agentskit',
+} as const;
+
+/** Repos whose stars are summed for the "across the ecosystem" header badge. */
+export const ECOSYSTEM_REPOS = [
+  'AgentsKit-io/agentskit',
+  'AgentsKit-io/agentskit-os',
+  'AgentsKit-io/agentskit-registry',
+  'AgentsKit-io/agents-playbook',
+  'EmersonBraun/ai-summary-hub',
+  'EmersonBraun/skills',
+] as const;
+
+/** Last-known total — served if the GitHub API is unreachable or rate-limited. */
+const FALLBACK_STARS = 18;
+
+/**
+ * The ecosystem nav: a single "learn → build → ship" story. Each step is a
+ * real product, cross-linked with UTM so the funnel is measurable.
+ */
+export const ECOSYSTEM_LINKS: Record<
+  Locale,
+  { menuLabel: string; items: { label: string; sub: string; href: string; external: boolean }[] }
+> = {
+  en: {
+    menuLabel: 'Ecosystem',
+    items: [
+      {
+        label: 'AgentsKit',
+        sub: 'Build agents in JavaScript',
+        href: ECOSYSTEM.agentskit,
+        external: true,
+      },
+      {
+        label: 'AKOS',
+        sub: 'Ship & orchestrate in production',
+        href: `https://akos.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Registry',
+        sub: 'Pre-built production agents',
+        href: `https://registry.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Playbook',
+        sub: 'Enterprise AI engineering standards',
+        href: `https://playbook.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Skills',
+        sub: 'Reusable AI skills for Claude Code',
+        href: 'https://github.com/EmersonBraun/skills',
+        external: true,
+      },
+    ],
+  },
+  'pt-BR': {
+    menuLabel: 'Ecossistema',
+    items: [
+      {
+        label: 'AgentsKit',
+        sub: 'Construa agentes em JavaScript',
+        href: ECOSYSTEM.agentskit,
+        external: true,
+      },
+      {
+        label: 'AKOS',
+        sub: 'Orquestre e suba em produção',
+        href: `https://akos.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Registry',
+        sub: 'Agentes de produção prontos',
+        href: `https://registry.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Playbook',
+        sub: 'Padrões de engenharia de IA enterprise',
+        href: `https://playbook.agentskit.io?${UTM}`,
+        external: true,
+      },
+      {
+        label: 'Skills',
+        sub: 'Skills de IA reutilizáveis para Claude Code',
+        href: 'https://github.com/EmersonBraun/skills',
+        external: true,
+      },
+    ],
+  },
+};
+
+/**
+ * Sum GitHub stars across the whole ecosystem. Cached for 6h via the Next
+ * fetch cache so we never hammer the unauthenticated API (60 req/h/IP). Any
+ * failure falls back to the last-known total — the header never breaks.
+ */
+export async function getEcosystemStars(): Promise<number> {
+  try {
+    const counts = await Promise.all(
+      ECOSYSTEM_REPOS.map(async (slug) => {
+        const res = await fetch(`https://api.github.com/repos/${slug}`, {
+          headers: { Accept: 'application/vnd.github+json' },
+          next: { revalidate: 21600 },
+        });
+        if (!res.ok) throw new Error(`${slug}: ${res.status}`);
+        const data = (await res.json()) as { stargazers_count?: number };
+        return data.stargazers_count ?? 0;
+      }),
+    );
+    const total = counts.reduce((a, b) => a + b, 0);
+    return total > 0 ? total : FALLBACK_STARS;
+  } catch {
+    return FALLBACK_STARS;
+  }
+}

--- a/next/lib/layout.shared.tsx
+++ b/next/lib/layout.shared.tsx
@@ -1,14 +1,43 @@
 import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
+import { EcosystemStars } from '@/components/ecosystem-stars';
+import { ECOSYSTEM_LINKS, getEcosystemStars } from '@/lib/ecosystem';
+import type { Locale } from '@/lib/site';
 
-export const baseOptions: BaseLayoutProps = {
-  nav: {
-    title: 'AI Summary Hub',
-  },
-  links: [
-    {
-      text: 'Docs',
-      url: '/docs',
-      active: 'nested-url',
+/**
+ * Shared nav/header config for every layout. Async because the ecosystem star
+ * badge is fetched + summed at request time (cached 6h). Both the home and
+ * docs layouts await this so the header is identical across the site.
+ */
+export async function getBaseOptions(lang: Locale): Promise<BaseLayoutProps> {
+  const stars = await getEcosystemStars();
+  const eco = ECOSYSTEM_LINKS[lang];
+  const docsUrl = lang === 'en' ? '/docs' : `/${lang}/docs`;
+
+  return {
+    nav: {
+      title: 'AI Summary Hub',
     },
-  ],
-};
+    links: [
+      {
+        text: 'Docs',
+        url: docsUrl,
+        active: 'nested-url',
+      },
+      {
+        type: 'menu',
+        text: eco.menuLabel,
+        items: eco.items.map((item) => ({
+          text: item.label,
+          description: item.sub,
+          url: item.href,
+          external: item.external,
+        })),
+      },
+      {
+        type: 'custom',
+        secondary: true,
+        children: <EcosystemStars stars={stars} lang={lang} />,
+      },
+    ],
+  };
+}

--- a/next/lib/posthog-client.ts
+++ b/next/lib/posthog-client.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import posthog from "posthog-js";
+
+let initialized = false;
+
+export function initPostHog(): void {
+  if (initialized || typeof window === "undefined") return;
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) return;
+  initialized = true;
+  posthog.init(key, {
+    api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "https://us.i.posthog.com",
+    capture_pageview: "history_change",
+    capture_pageleave: true,
+    capture_exceptions: true,
+    person_profiles: "always",
+    // Share the analytics cookie across *.emersonbraun.dev / *.agentskit.io /
+    // aisummaryhub.dev so a visitor stays the same person as they move through
+    // the ecosystem funnel.
+    cross_subdomain_cookie: true,
+    autocapture: true,
+  });
+}
+
+export function track(event: string, props?: Record<string, unknown>): void {
+  if (typeof window === "undefined") return;
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) posthog.capture(event, props);
+}
+
+export function identify(
+  distinctId: string,
+  props?: Record<string, unknown>
+): void {
+  if (typeof window === "undefined") return;
+  if (process.env.NEXT_PUBLIC_POSTHOG_KEY) posthog.identify(distinctId, props);
+}

--- a/next/lib/site.ts
+++ b/next/lib/site.ts
@@ -69,7 +69,7 @@ export const FEATURED_CATEGORIES: Array<{
 
 export const HOME_COPY = {
   en: {
-    eyebrow: 'Open knowledge wiki',
+    eyebrow: 'The learn layer of the AgentsKit ecosystem',
     cta_primary: 'Explore docs',
     cta_secondary: 'View on GitHub',
     stats: [
@@ -84,7 +84,7 @@ export const HOME_COPY = {
     final_cta_subtitle: 'No paywalls, no fluff — just concise, cited summaries.',
   },
   'pt-BR': {
-    eyebrow: 'Wiki aberta de conhecimento',
+    eyebrow: 'A camada de aprendizado do ecossistema AgentsKit',
     cta_primary: 'Explorar docs',
     cta_secondary: 'Ver no GitHub',
     stats: [

--- a/next/package-lock.json
+++ b/next/package-lock.json
@@ -14,6 +14,7 @@
         "fumadocs-ui": "latest",
         "mermaid": "^11.15.0",
         "next": "^16.0.0",
+        "posthog-js": "^1.245.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "unist-util-visit": "^5.1.0"
@@ -1270,6 +1271,21 @@
       "engines": {
         "node": ">= 20.0.0"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.32.3",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.32.3.tgz",
+      "integrity": "sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.386.3"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.386.3",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.386.3.tgz",
+      "integrity": "sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==",
+      "license": "MIT"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -3045,6 +3061,17 @@
       "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==",
       "license": "MIT"
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cose-base": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
@@ -3898,6 +3925,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/framer-motion": {
       "version": "12.38.0",
@@ -6165,6 +6198,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.386.6",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.386.6.tgz",
+      "integrity": "sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@posthog/core": "^1.32.3",
+        "@posthog/types": "^1.386.3",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
+      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -6174,6 +6233,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.2.6",
@@ -7039,6 +7104,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
+      "license": "Apache-2.0"
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/next/package.json
+++ b/next/package.json
@@ -15,6 +15,7 @@
     "fumadocs-ui": "latest",
     "mermaid": "^11.15.0",
     "next": "^16.0.0",
+    "posthog-js": "^1.245.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "unist-util-visit": "^5.1.0"


### PR DESCRIPTION
## What

Makes **AI Summary Hub** a coherent part of the AgentsKit ecosystem (agentskit.io / emersonbraun.dev). All cross-links flow **outward only** — Hub → ecosystem, to funnel visitors into AgentsKit. Nothing pulls the other direction.

## Changes

- **Header** — summed GitHub stars across 6 ecosystem repos (`★ 18 across the ecosystem`, cached 6h, graceful fallback) + new **Ecosystem** nav dropdown (AgentsKit · AKOS · Registry · Playbook · Skills)
- **Palette** — violet `#6d5cff` promoted to primary to match the AgentsKit brand; `fd-primary` pinned to violet so docs UI matches the landing; teal demoted to a secondary micro-accent
- **Narrative** — Learn → Build → Ship funnel band with a "You are here" marker on Learn; eyebrow + sections reframed around the ecosystem
- **Footer** — "Open Source" column → "Ecosystem" with the full product list, sourced from a shared `ECOSYSTEM_LINKS`
- **Analytics** — PostHog + funnel banner with `utm_source=aisummaryhub` for a measurable outbound funnel
- **i18n** — bilingual EN + pt-BR throughout

`lib/ecosystem.ts` is the single source of truth for ecosystem links and the star sum.

## Verification

- `tsc --noEmit` clean
- `next build` green (404 static pages)
- Local smoke test: `/en`, `/pt-BR`, `/docs` all 200