### PR TITLE
fix(docs): repair broken mermaid diagrams + missing edge-ai landing

### DIFF
--- a/next/content/docs/en/claude-code/context-management.mdx
+++ b/next/content/docs/en/claude-code/context-management.mdx
@@ -44,7 +44,7 @@ flowchart LR
   Model -->|response + new tool calls| History
   History -->|approaching limit| Compress[Auto-compression<br/>old turns summarized]
   Compress -->|trimmed history| Assemble
-  Clear[/clear command] -->|resets| History
+  Clear["/clear command"] -->|resets| History
 ```
 
 ## When to use / When NOT to use

--- a/next/content/docs/en/edge-ai/index.mdx
+++ b/next/content/docs/en/edge-ai/index.mdx
@@ -1,0 +1,40 @@
+---
+title: Edge AI
+description: >-
+  Running ML inference directly on devices — phones, browsers, embedded systems,
+  and microcontrollers — with on-device runtimes like ONNX Runtime, TensorFlow
+  Lite, and PyTorch Mobile.
+tags:
+  - intermediate
+---
+
+## Definition
+
+**Edge AI** is the practice of running machine learning inference directly on the device that captures the data — a phone, browser, camera, vehicle, wearable, or microcontroller — instead of sending that data to a remote server. By keeping computation local, edge AI cuts network latency, works offline, reduces cloud costs, and keeps sensitive data on-device for privacy.
+
+The trade-off is constraint: edge hardware has far less memory, compute, and power than a datacenter GPU. Edge AI is therefore as much about **model compression** — [quantization](/docs/quantization), pruning, and distillation — as it is about the runtimes that execute those compressed models efficiently on heterogeneous hardware (CPUs, mobile GPUs, NPUs, and DSPs).
+
+## How it works
+
+```mermaid
+flowchart LR
+  Model[Trained model<br/>PyTorch / TensorFlow] -->|export| Format[Portable format<br/>ONNX / TFLite / ExecuTorch]
+  Format -->|optimize| Opt[Quantize · prune<br/>fuse ops]
+  Opt -->|deploy| Runtime[On-device runtime]
+  Runtime -->|CPU / GPU / NPU| Device[Phone · browser<br/>embedded · MCU]
+```
+
+A typical edge pipeline takes a model trained with a full framework, exports it to a portable format, optimizes it for the target hardware, and runs it through a lightweight on-device runtime. Each runtime in this category targets a different slice of that landscape.
+
+## Runtimes in this category
+
+- [**ONNX Runtime**](/docs/edge-ai/onnx) — Cross-platform inference engine for ONNX models with CPU, GPU, and NPU execution providers.
+- [**TensorFlow Lite**](/docs/edge-ai/tflite) — Lightweight runtime for on-device inference across Android, iOS, embedded systems, and microcontrollers.
+- [**PyTorch Mobile**](/docs/edge-ai/pytorch-mobile) — Deploy PyTorch models on mobile and edge devices using TorchScript and the next-generation ExecuTorch runtime.
+
+## See also
+
+- [Quantization](/docs/quantization)
+- [Inference optimization](/docs/inference-optimization)
+- [Local inference](/docs/local-inference)
+- [Frameworks](/docs/frameworks)

--- a/next/content/docs/en/edge-ai/meta.json
+++ b/next/content/docs/en/edge-ai/meta.json
@@ -1,5 +1,6 @@
 {
   "pages": [
+    "index",
     "tflite",
     "pytorch-mobile",
     "onnx"

--- a/next/content/docs/en/model-providers/openai.mdx
+++ b/next/content/docs/en/model-providers/openai.mdx
@@ -29,7 +29,7 @@ GPT-5.4 and GPT-5.5 support five reasoning modes — `none`, `low`, `medium`, `h
 
 ```mermaid
 flowchart LR
-  Client[Client app] -->|POST messages array| ChatAPI[/v1/chat/completions]
+  Client[Client app] -->|POST messages array| ChatAPI["/v1/chat/completions"]
   ChatAPI -->|model routing| Selector{Model<br/>selector}
   Selector -->|flagship| GPT55[GPT-5.5]
   Selector -->|balanced| GPT54[GPT-5.4]

--- a/next/content/docs/en/nlp/text-classification.mdx
+++ b/next/content/docs/en/nlp/text-classification.mdx
@@ -22,7 +22,7 @@ flowchart LR
   Text[Input text] -->|tokenize| Enc[Transformer encoder]
   Enc -->|CLS pooling| Pool[Pooled embedding]
   Pool -->|linear layer| Logits[Class logits]
-  Logits -->|softmax / sigmoid| Pred[Predicted label\(s\)]
+  Logits -->|softmax / sigmoid| Pred["Predicted label(s)"]
 ```
 
 1. **Tokenize** — text is split into subword tokens (BPE, WordPiece) and mapped to embeddings with positional encodings.

--- a/next/content/docs/pt-BR/claude-code/context-management.mdx
+++ b/next/content/docs/pt-BR/claude-code/context-management.mdx
@@ -44,7 +44,7 @@ flowchart LR
   Model -->|response + new tool calls| History
   History -->|approaching limit| Compress[Auto-compression<br/>old turns summarized]
   Compress -->|trimmed history| Assemble
-  Clear[/clear command] -->|resets| History
+  Clear["/clear command"] -->|resets| History
 ```
 
 ## Quando usar / Quando NÃO usar

--- a/next/content/docs/pt-BR/edge-ai/index.mdx
+++ b/next/content/docs/pt-BR/edge-ai/index.mdx
@@ -1,0 +1,40 @@
+---
+title: Edge AI
+description: >-
+  Executar inferência de ML diretamente nos dispositivos — celulares,
+  navegadores, sistemas embarcados e microcontroladores — com runtimes no
+  dispositivo como ONNX Runtime, TensorFlow Lite e PyTorch Mobile.
+tags:
+  - intermediate
+---
+
+## Definição
+
+**Edge AI** (IA na borda) é a prática de executar inferência de machine learning diretamente no dispositivo que captura os dados — um celular, navegador, câmera, veículo, wearable ou microcontrolador — em vez de enviar esses dados para um servidor remoto. Ao manter a computação local, a IA na borda reduz a latência de rede, funciona offline, corta custos de nuvem e mantém dados sensíveis no dispositivo, preservando a privacidade.
+
+O trade-off é a restrição: o hardware de borda tem muito menos memória, processamento e energia que uma GPU de datacenter. A IA na borda é, portanto, tanto sobre **compressão de modelos** — [quantização](/docs/quantization), pruning e destilação — quanto sobre os runtimes que executam esses modelos comprimidos de forma eficiente em hardware heterogêneo (CPUs, GPUs móveis, NPUs e DSPs).
+
+## Como funciona
+
+```mermaid
+flowchart LR
+  Model[Modelo treinado<br/>PyTorch / TensorFlow] -->|exportar| Format[Formato portátil<br/>ONNX / TFLite / ExecuTorch]
+  Format -->|otimizar| Opt[Quantizar · prune<br/>fundir ops]
+  Opt -->|deploy| Runtime[Runtime no dispositivo]
+  Runtime -->|CPU / GPU / NPU| Device[Celular · navegador<br/>embarcado · MCU]
+```
+
+Um pipeline de borda típico pega um modelo treinado com um framework completo, exporta para um formato portátil, otimiza para o hardware alvo e o executa através de um runtime leve no dispositivo. Cada runtime desta categoria atende a uma fatia diferente desse cenário.
+
+## Runtimes nesta categoria
+
+- [**ONNX Runtime**](/docs/edge-ai/onnx) — Motor de inferência multiplataforma para modelos ONNX com provedores de execução em CPU, GPU e NPU.
+- [**TensorFlow Lite**](/docs/edge-ai/tflite) — Runtime leve para inferência no dispositivo em Android, iOS, sistemas embarcados e microcontroladores.
+- [**PyTorch Mobile**](/docs/edge-ai/pytorch-mobile) — Implante modelos PyTorch em dispositivos móveis e de borda usando TorchScript e o runtime de próxima geração ExecuTorch.
+
+## Veja também
+
+- [Quantização](/docs/quantization)
+- [Otimização de inferência](/docs/inference-optimization)
+- [Inferência local](/docs/local-inference)
+- [Frameworks](/docs/frameworks)

--- a/next/content/docs/pt-BR/edge-ai/meta.json
+++ b/next/content/docs/pt-BR/edge-ai/meta.json
@@ -1,5 +1,6 @@
 {
   "pages": [
+    "index",
     "tflite",
     "pytorch-mobile",
     "onnx"

--- a/next/content/docs/pt-BR/model-providers/openai.mdx
+++ b/next/content/docs/pt-BR/model-providers/openai.mdx
@@ -29,7 +29,7 @@ GPT-5.4 e GPT-5.5 suportam cinco modos de raciocínio — `none`, `low`, `medium
 
 ```mermaid
 flowchart LR
-  Client[Client app] -->|POST messages array| ChatAPI[/v1/chat/completions]
+  Client[Client app] -->|POST messages array| ChatAPI["/v1/chat/completions"]
   ChatAPI -->|model routing| Selector{Model<br/>selector}
   Selector -->|flagship| GPT55[GPT-5.5]
   Selector -->|balanced| GPT54[GPT-5.4]

--- a/next/content/docs/pt-BR/nlp/text-classification.mdx
+++ b/next/content/docs/pt-BR/nlp/text-classification.mdx
@@ -22,7 +22,7 @@ flowchart LR
   Text[Texto de entrada] -->|tokenizar| Enc[Encoder Transformer]
   Enc -->|CLS pooling| Pool[Embedding agrupado]
   Pool -->|camada linear| Logits[Logits de classe]
-  Logits -->|softmax / sigmoid| Pred[Rótulo\(s\) previsto\(s\)]
+  Logits -->|softmax / sigmoid| Pred["Rótulo(s) previsto(s)"]
 ```
 
 1. **Tokenizar** — o texto é dividido em tokens de subpalavras (BPE, WordPiece) e mapeado para embeddings com codificações posicionais.


### PR DESCRIPTION
## Broken mermaid (lexical errors)

Unquoted node labels with `/` or escaped parens were parsed as mermaid shape syntax (e.g. `[/text]` = trapezoid), throwing `Syntax error in text`. Fixed by quoting the labels:

| File (en + pt-BR) | Before | After |
|---|---|---|
| `model-providers/openai` | `ChatAPI[/v1/chat/completions]` | `ChatAPI["/v1/chat/completions"]` |
| `claude-code/context-management` | `Clear[/clear command]` | `Clear["/clear command"]` |
| `nlp/text-classification` | `Pred[Predicted label\(s\)]` | `Pred["Predicted label(s)"]` |

## Missing page / dead link

`edge-ai/` had 3 pages (onnx, tflite, pytorch-mobile) but **no `index.mdx`**, so `/docs/edge-ai` 404'd — and `frameworks` "See also" linked straight to it. Added a category landing (en + pt-BR) with intro, diagram, child links, and listed `index` first in `meta.json`.

## Method

Wrote a linter that scanned **all 365 mermaid blocks** and every internal docs link. Remaining flags are non-issues: one already-quoted valid diagram, and `/docs/path` placeholders inside a code-fence template in `contributing.mdx`.

## Verification

- `next build` green — **406** static pages (+2 edge-ai landings)