### PR TITLE
docs(contributing): replace template placeholders with real examples

### DIFF
--- a/next/content/docs/en/contributing.mdx
+++ b/next/content/docs/en/contributing.mdx
@@ -160,14 +160,14 @@ Explanation with diagram:
 
 ## Practical resources
 
-- [Official docs](https://example.com) — Description
-- [Tutorial or course](https://example.com) — Description
-- [GitHub repo](https://example.com) — Description
+- [Attention Is All You Need](https://arxiv.org/abs/1706.03762) — The paper that introduced the transformer architecture.
+- [Hugging Face course](https://huggingface.co/learn/nlp-course) — Free, hands-on course on transformers and NLP.
+- [pytorch/pytorch](https://github.com/pytorch/pytorch) — Reference implementation and source.
 
 ## See also
 
-- [Related doc 1](/docs/path)
-- [Related doc 2](/docs/path)
+- [Transformers](/docs/transformers)
+- [LLMs](/docs/llms)
 ```
 
 ## Adding new topics

--- a/next/content/docs/pt-BR/contributing.mdx
+++ b/next/content/docs/pt-BR/contributing.mdx
@@ -160,14 +160,14 @@ Explicação com diagrama:
 
 ## Recursos práticos
 
-- [Documentação oficial](https://example.com) — Descrição
-- [Tutorial ou curso](https://example.com) — Descrição
-- [Repositório GitHub](https://example.com) — Descrição
+- [Attention Is All You Need](https://arxiv.org/abs/1706.03762) — O paper que introduziu a arquitetura transformer.
+- [Curso da Hugging Face](https://huggingface.co/learn/nlp-course) — Curso gratuito e prático sobre transformers e NLP.
+- [pytorch/pytorch](https://github.com/pytorch/pytorch) — Implementação de referência e código-fonte.
 
 ## Veja também
 
-- [Documento relacionado 1](/docs/caminho)
-- [Documento relacionado 2](/docs/caminho)
+- [Transformers](/docs/transformers)
+- [LLMs](/docs/llms)
 ```
 
 ## Adicionando novos tópicos


### PR DESCRIPTION
Replaces the dummy `https://example.com` / `/docs/path` placeholders in the article-template section of `contributing.mdx` (en + pt-BR) with real, working references (arXiv transformer paper, Hugging Face course, pytorch repo) and valid internal links (`/docs/transformers`, `/docs/llms`). Link audit: 0 broken internal docs links.