### PR TITLE
docs(contributing): update guide for fumadocs/Next stack

### DIFF
--- a/next/content/docs/en/contributing.mdx
+++ b/next/content/docs/en/contributing.mdx
@@ -66,29 +66,19 @@ Every doc must include this frontmatter block:
 ---
 title: "Full article title"
 description: "One-line description for SEO and search"
-keywords: [keyword1, keyword2, keyword3]
 tags: [intermediate]  # exactly one of: beginner, intermediate, advanced
-authors: [GitHubUsername]  # GitHub username(s) of author(s)
 ---
 ```
 
-**Required fields:**
+**Fields:**
 
-| Field | Description |
-|-------|-------------|
-| `title` | Full article title |
-| `description` | One-line description (used for SEO and search) |
-| `keywords` | Array of relevant keywords |
-| `tags` | Array containing **exactly one** level tag: `beginner`, `intermediate`, or `advanced` |
-| `authors` | Array of GitHub usernames who wrote the article |
+| Field | Required | Description |
+|-------|----------|-------------|
+| `title` | yes | Full article title — also used as the sidebar label and the page `<h1>` |
+| `description` | yes | One-line description (used for SEO, social cards, and search) |
+| `tags` | yes | Array containing **exactly one** level tag: `beginner`, `intermediate`, or `advanced` |
 
-**Optional fields:**
-
-| Field | Description | When to use |
-|-------|-------------|-------------|
-| `sidebar_label` | Short label for the sidebar | Only when the title exceeds ~30 characters |
-
-**Note:** `last_updated` is handled automatically by Docusaurus via git history. Do not add it manually.
+Do not add an `# H1` heading in the body — fumadocs renders the `title` as the page heading automatically. Start the body directly with `## Definition`.
 
 ### Complete template example
 
@@ -96,12 +86,8 @@ authors: [GitHubUsername]  # GitHub username(s) of author(s)
 ---
 title: "Example Topic"
 description: "A brief description of the topic."
-keywords: [topic, example, ai]
 tags: [intermediate]
-authors: [YourGitHubUsername]
 ---
-
-# Example Topic
 
 ## Definition
 
@@ -172,54 +158,61 @@ Explanation with diagram:
 
 ## Adding new topics
 
-1. Create a new file under `docs/` in the right category (e.g. `docs/tools/my-tool.md`).
-2. Use the template above and ensure a unique doc ID (path-based).
+Content lives under `content/docs/<lang>/`, and routing is path-based: the file
+`content/docs/en/tools/my-tool.mdx` is served at `/docs/tools/my-tool`.
+
+1. Create a new `.mdx` file in the right category, e.g. `content/docs/en/tools/my-tool.mdx`.
+2. Use the template above (start the body at `## Definition` — no `# H1`).
 3. Include **all mandatory sections** and relevant optional sections.
-4. Add the doc to `sidebars.ts` in the right category.
-5. If your article includes a **Comparison** to another article, update that article with a reciprocal comparison.
-6. Open a PR with a short description.
+4. Add the file's slug to the category's `meta.json` `pages` array — this controls sidebar order.
+5. **New category?** Create the folder with a `meta.json` (`title` + `pages`, with `index` first) and an `index.mdx` landing page.
+6. If your article includes a **Comparison** to another article, update that article with a reciprocal comparison.
+7. Open a PR with a short description.
+
+A `meta.json` looks like:
+
+```json
+{
+  "title": "Tools",
+  "pages": ["index", "my-tool", "another-tool"]
+}
+```
 
 ## Improving examples
 
 - Prefer runnable code; add comments if dependencies or setup are non-obvious.
-- Use Prism-supported languages (Python, JavaScript, TypeScript, bash, yaml, docker).
+- Use fenced code blocks with a language tag — highlighting is handled by [Shiki](https://shiki.style/) (Python, JavaScript, TypeScript, bash, yaml, json, docker, and more).
 - Link to official docs or repos where relevant.
 
 ## Diagrams (Mermaid)
 
-Diagrams in the docs are written in [Mermaid](https://mermaid.js.org/intro/getting-started.html) and rendered by the site via Docusaurus. Guidelines:
+Diagrams are written in [Mermaid](https://mermaid.js.org/intro/getting-started.html) in a ` ```mermaid ` fenced block and rendered client-side by the site. Guidelines:
 
 - Use valid Mermaid.js syntax — test in the [Mermaid Live Editor](https://mermaid.live/) before submitting.
+- **Quote any node label that contains `/`, `(`, `)`, or `:`** — e.g. write `Api["/v1/chat"]`, not `Api[/v1/chat]`. Unquoted special characters are parsed as shape syntax and break the render.
+- For line breaks inside a label use `<br/>`, not `\n`.
 - **Label edges** to describe relationships (not just boxes connected by arrows).
 - Use subgraphs to group related components when diagrams have 5+ nodes.
 - Prefer `flowchart LR` or `flowchart TD` for architecture; `sequenceDiagram` for interactions.
 
 ## Translations
 
-The site is localized for **Spanish (es), Portuguese (pt-BR), German (de), French (fr), and Simplified Chinese (zh-Hans)**. Default content is in English.
+Content is available in **English (en)** and **Portuguese (pt-BR)**. English is the source of truth.
 
-New articles are produced in **English only**. Translations are handled in a separate phase.
+Each language is a parallel tree under `content/docs/<lang>/` — there is no separate translation-JSON layer. To translate a page:
 
-**Where translation files live:**
+- Mirror the same folder structure and file name across languages, e.g.
+  `content/docs/en/agents/index.mdx` ↔ `content/docs/pt-BR/agents/index.mdx`.
+- Translate the frontmatter `title` and `description` and the body. Keep `tags` identical.
+- Each language folder has its own `meta.json`: translate its `title`, but keep the `pages` slugs identical across languages (slugs are language-agnostic).
+- Keep internal links as `/docs/...` (no locale prefix) — the locale is inferred from the folder.
 
-- **Sidebar and doc labels:** `i18n/<locale>/docusaurus-plugin-content-docs/current.json` (sidebar category labels). Doc titles come from each translated doc's front matter in `i18n/<locale>/docusaurus-plugin-content-docs/current/`.
-- **Navbar:** `i18n/<locale>/docusaurus-theme-classic/navbar.json`
-- **Footer:** `i18n/<locale>/docusaurus-theme-classic/footer.json`
-- **Theme UI and custom pages (home, all-topics):** `i18n/<locale>/code.json`
-- **Doc content:** Mirror the `docs/` tree under `i18n/<locale>/docusaurus-plugin-content-docs/current/` and translate each `.md` (front matter `title`, `description`, and body). Keep internal links as `/docs/...` so they work with the locale prefix.
-
-**Adding a new locale:** Add the locale to `i18n.locales` in `docusaurus.config.ts`, then run `npm run write-translations` (optionally with `--locale <locale>`) to generate the JSON structure. Fill in translations for navbar, footer, `code.json`, sidebar, and doc content.
-
-**When to run `write-translations`:** Run `npm run write-translations` when you add new sidebar items, theme strings, or custom page keys so that new keys appear in each locale's JSON files for translators.
+**Adding a new locale:** add it to `languages` in `lib/i18n.ts`, create the `content/docs/<lang>/` tree, and translate the UI copy in `lib/site.ts` (`HOME_COPY`, `FEATURED_CATEGORIES`) plus the footer and ecosystem nav components.
 
 ## Code style and commits
 
-- Follow existing formatting (e.g. 2 spaces, trailing newline).
-- Use clear commit messages (e.g. "Add doc: X", "Fix link in Y").
-
-## Versioning
-
-When the content baseline is stable, maintainers may run `npm run docusaurus docs:version 1.0.0` to create versioned snapshots. The version selector will appear in the navbar. See [Docusaurus versioning](https://docusaurus.io/docs/versioning) for details.
+- Follow existing formatting (2 spaces, trailing newline).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) — e.g. `docs(agents): add planner-executor`, `fix(mermaid): quote node label`.
 
 ---
 

--- a/next/content/docs/pt-BR/contributing.mdx
+++ b/next/content/docs/pt-BR/contributing.mdx
@@ -66,29 +66,19 @@ Cada documento deve incluir este bloco de frontmatter:
 ---
 title: "Título completo do artigo"
 description: "Descrição de uma linha para SEO e busca"
-keywords: [keyword1, keyword2, keyword3]
 tags: [intermediate]  # exatamente um de: beginner, intermediate, advanced
-authors: [NomeUsuarioGitHub]  # nome(s) de usuário do GitHub do(s) autor(es)
 ---
 ```
 
-**Campos obrigatórios:**
+**Campos:**
 
-| Campo | Descrição |
-|-------|-----------|
-| `title` | Título completo do artigo |
-| `description` | Descrição de uma linha (usada para SEO e busca) |
-| `keywords` | Array de palavras-chave relevantes |
-| `tags` | Array contendo **exatamente uma** tag de nível: `beginner`, `intermediate` ou `advanced` |
-| `authors` | Array de nomes de usuário do GitHub que escreveram o artigo |
+| Campo | Obrigatório | Descrição |
+|-------|-------------|-----------|
+| `title` | sim | Título completo do artigo — também usado como rótulo da barra lateral e como o `<h1>` da página |
+| `description` | sim | Descrição de uma linha (usada para SEO, cards sociais e busca) |
+| `tags` | sim | Array contendo **exatamente uma** tag de nível: `beginner`, `intermediate` ou `advanced` |
 
-**Campos opcionais:**
-
-| Campo | Descrição | Quando usar |
-|-------|-----------|-------------|
-| `sidebar_label` | Rótulo curto para a barra lateral | Apenas quando o título excede ~30 caracteres |
-
-**Nota:** `last_updated` é gerenciado automaticamente pelo Docusaurus via histórico do git. Não o adicione manualmente.
+Não adicione um título `# H1` no corpo — o fumadocs renderiza o `title` como o cabeçalho da página automaticamente. Comece o corpo direto com `## Definição`.
 
 ### Exemplo completo de modelo
 
@@ -96,12 +86,8 @@ authors: [NomeUsuarioGitHub]  # nome(s) de usuário do GitHub do(s) autor(es)
 ---
 title: "Tópico Exemplo"
 description: "Uma breve descrição do tópico."
-keywords: [topico, exemplo, ia]
 tags: [intermediate]
-authors: [SeuNomeUsuarioGitHub]
 ---
-
-# Tópico Exemplo
 
 ## Definição
 
@@ -172,54 +158,61 @@ Explicação com diagrama:
 
 ## Adicionando novos tópicos
 
-1. Crie um novo arquivo em `docs/` na categoria correta (p. ex. `docs/tools/minha-ferramenta.md`).
-2. Use o modelo acima e garanta um ID de documento único (baseado no caminho).
+O conteúdo fica em `content/docs/<lang>/`, e o roteamento é baseado no caminho: o
+arquivo `content/docs/en/tools/minha-ferramenta.mdx` é servido em `/docs/tools/minha-ferramenta`.
+
+1. Crie um novo arquivo `.mdx` na categoria correta, p. ex. `content/docs/en/tools/minha-ferramenta.mdx`.
+2. Use o modelo acima (comece o corpo em `## Definição` — sem `# H1`).
 3. Inclua **todas as seções obrigatórias** e seções opcionais relevantes.
-4. Adicione o documento a `sidebars.ts` na categoria correta.
-5. Se seu artigo inclui uma **Comparação** com outro artigo, atualize esse artigo com uma comparação recíproca.
-6. Abra um PR com uma breve descrição.
+4. Adicione o slug do arquivo ao array `pages` do `meta.json` da categoria — isso controla a ordem da barra lateral.
+5. **Categoria nova?** Crie a pasta com um `meta.json` (`title` + `pages`, com `index` primeiro) e uma página `index.mdx` de entrada.
+6. Se seu artigo inclui uma **Comparação** com outro artigo, atualize esse artigo com uma comparação recíproca.
+7. Abra um PR com uma breve descrição.
+
+Um `meta.json` se parece com:
+
+```json
+{
+  "title": "Tools",
+  "pages": ["index", "minha-ferramenta", "outra-ferramenta"]
+}
+```
 
 ## Melhorando exemplos
 
 - Prefira código executável; adicione comentários se dependências ou configuração não forem óbvias.
-- Use linguagens suportadas pelo Prism (Python, JavaScript, TypeScript, bash, yaml, docker).
+- Use blocos de código cercados com a tag de linguagem — o destaque é feito pelo [Shiki](https://shiki.style/) (Python, JavaScript, TypeScript, bash, yaml, json, docker e mais).
 - Vincule à documentação oficial ou repositórios onde relevante.
 
 ## Diagramas (Mermaid)
 
-Os diagramas nos docs são escritos em [Mermaid](https://mermaid.js.org/intro/getting-started.html) e renderizados pelo site via Docusaurus. Diretrizes:
+Os diagramas são escritos em [Mermaid](https://mermaid.js.org/intro/getting-started.html) em um bloco cercado ` ```mermaid ` e renderizados no cliente pelo site. Diretrizes:
 
 - Use sintaxe Mermaid.js válida — teste no [Mermaid Live Editor](https://mermaid.live/) antes de enviar.
+- **Coloque entre aspas qualquer rótulo de nó que contenha `/`, `(`, `)` ou `:`** — p. ex. escreva `Api["/v1/chat"]`, não `Api[/v1/chat]`. Caracteres especiais sem aspas são interpretados como sintaxe de forma e quebram a renderização.
+- Para quebras de linha dentro de um rótulo, use `<br/>`, não `\n`.
 - **Rotule as arestas** para descrever relacionamentos (não apenas caixas conectadas por setas).
 - Use subgrafos para agrupar componentes relacionados quando os diagramas tiverem 5+ nós.
 - Prefira `flowchart LR` ou `flowchart TD` para arquitetura; `sequenceDiagram` para interações.
 
 ## Traduções
 
-O site é localizado para **espanhol (es), português (pt-BR), alemão (de), francês (fr) e chinês simplificado (zh-Hans)**. O conteúdo padrão está em inglês.
+O conteúdo está disponível em **inglês (en)** e **português (pt-BR)**. O inglês é a fonte da verdade.
 
-Novos artigos são produzidos **apenas em inglês**. As traduções são tratadas em uma fase separada.
+Cada idioma é uma árvore paralela em `content/docs/<lang>/` — não há camada separada de JSON de tradução. Para traduzir uma página:
 
-**Onde ficam os arquivos de tradução:**
+- Espelhe a mesma estrutura de pastas e nome de arquivo entre os idiomas, p. ex.
+  `content/docs/en/agents/index.mdx` ↔ `content/docs/pt-BR/agents/index.mdx`.
+- Traduza o `title` e a `description` do frontmatter e o corpo. Mantenha `tags` idêntico.
+- Cada pasta de idioma tem seu próprio `meta.json`: traduza o `title`, mas mantenha os slugs de `pages` idênticos entre idiomas (slugs são agnósticos de idioma).
+- Mantenha os links internos como `/docs/...` (sem prefixo de locale) — o locale é inferido a partir da pasta.
 
-- **Rótulos de barra lateral e documento:** `i18n/<locale>/docusaurus-plugin-content-docs/current.json` (rótulos de categoria de barra lateral). Os títulos dos documentos vêm do frontmatter de cada documento traduzido em `i18n/<locale>/docusaurus-plugin-content-docs/current/`.
-- **Barra de navegação:** `i18n/<locale>/docusaurus-theme-classic/navbar.json`
-- **Rodapé:** `i18n/<locale>/docusaurus-theme-classic/footer.json`
-- **UI do tema e páginas personalizadas (home, all-topics):** `i18n/<locale>/code.json`
-- **Conteúdo do documento:** Espelhe a árvore `docs/` sob `i18n/<locale>/docusaurus-plugin-content-docs/current/` e traduza cada `.md` (frontmatter `title`, `description` e corpo). Mantenha links internos como `/docs/...` para que funcionem com o prefixo de locale.
-
-**Adicionando uma nova localidade:** Adicione a localidade a `i18n.locales` em `docusaurus.config.ts`, depois execute `npm run write-translations` (opcionalmente com `--locale <locale>`) para gerar a estrutura JSON. Preencha as traduções para barra de navegação, rodapé, `code.json`, barra lateral e conteúdo do documento.
-
-**Quando executar `write-translations`:** Execute `npm run write-translations` ao adicionar novos itens de barra lateral, strings de tema ou chaves de páginas personalizadas para que novas chaves apareçam nos arquivos JSON de cada locale para os tradutores.
+**Adicionando um novo locale:** adicione-o a `languages` em `lib/i18n.ts`, crie a árvore `content/docs/<lang>/` e traduza a copy de UI em `lib/site.ts` (`HOME_COPY`, `FEATURED_CATEGORIES`) além dos componentes de footer e nav do ecossistema.
 
 ## Estilo de código e commits
 
-- Siga a formatação existente (p. ex. 2 espaços, nova linha no final).
-- Use mensagens de commit claras (p. ex. "Add doc: X", "Fix link in Y").
-
-## Versionamento
-
-Quando a base de conteúdo estiver estável, os mantenedores podem executar `npm run docusaurus docs:version 1.0.0` para criar snapshots versionados. O seletor de versão aparecerá na barra de navegação. Veja [Versionamento do Docusaurus](https://docusaurus.io/docs/versioning) para detalhes.
+- Siga a formatação existente (2 espaços, nova linha ao final).
+- Use [Conventional Commits](https://www.conventionalcommits.org/) — p. ex. `docs(agents): add planner-executor`, `fix(mermaid): quote node label`.
 
 ---
 


### PR DESCRIPTION
The contributing guide still documented the old **Docusaurus** setup (`sidebars.ts`, `i18n/<locale>/...current.json`, `write-translations`, Prism, Docusaurus versioning, and `keywords`/`authors`/`sidebar_label` frontmatter that the content doesn't use). Rewrote it to match the current **fumadocs + Next.js** pipeline (en + pt-BR).

## Changes

- **Frontmatter spec** — only the real fields (`title`, `description`, `tags`); removed `keywords`/`authors`/`sidebar_label` and the Docusaurus `last_updated` note. Added the "no `# H1` in body" rule (fumadocs renders `title`).
- **Adding topics** — `content/docs/<lang>/*.mdx` path-based routing; sidebar order via the category `meta.json` `pages` array (not `sidebars.ts`); new-category checklist (`meta.json` + `index.mdx`).
- **Mermaid** — added the rules that prevent the lexical errors fixed in #72: quote labels containing `/ ( ) :`, use `<br/>` not `\n`.
- **Translations** — parallel `content/docs/<lang>/` trees, no separate translation-JSON layer; new-locale steps via `lib/i18n.ts` + `lib/site.ts`.
- **Highlighting** — Shiki, not Prism. **Commits** — Conventional Commits. Removed the Docusaurus versioning section.

## Verification

- No remaining `docusaurus` / `sidebars.ts` / `prism` / `i18n/<locale>` / `keywords:` / `authors:` references
- `next build` green — 406 pages